### PR TITLE
Add missing "var"

### DIFF
--- a/browser/scripts/expander.js
+++ b/browser/scripts/expander.js
@@ -35,7 +35,7 @@
         factory((root.expander = {}), root._, root.parser);
     }
 }(this, function (exports, underscore, parser) {
-    _ = underscore || _;
+    var _ = underscore || _;
 
     // var CToken = object({
     //     type: Num,

--- a/lib/expander.js
+++ b/lib/expander.js
@@ -35,7 +35,7 @@
         factory((root.expander = {}), root._, root.parser);
     }
 }(this, function (exports, underscore, parser, es6) {
-    _ = underscore || _;
+    var _ = underscore || _;
     // used to export "private" methods for unit testing
     exports._test = {};
 

--- a/src/expander.js
+++ b/src/expander.js
@@ -35,7 +35,7 @@
         factory((root.expander = {}), root._, root.parser);
     }
 }(this, function (exports, underscore, parser, es6) {
-    _ = underscore || _;
+    var _ = underscore || _;
     // used to export "private" methods for unit testing
     exports._test = {};
 


### PR DESCRIPTION
Add a missing "var" declaration to the Underscore.js reference. Without it, "_" is added to the global object, causing unexpected errors.

Reproduce the problem, at the REPL:

```
var s = require("./lib/sweet"); process.nextTick(function () { s.compile("var foo = 1;"); });
```

This will throw the exception "TypeError: Cannot call method 'isArray' of undefined", since the globally available "_" at some point becomes undefined.
