### PR TITLE
do not rename variables declared in second and subsequent

### DIFF
--- a/lib/expander.js
+++ b/lib/expander.js
@@ -544,7 +544,9 @@
 
         return _.reduce(term.body.delim.token.inner, function(acc, curr) {
             if (curr.hasPrototype(VariableStatement)) {
-                return acc.concat(curr.decls[0].ident);
+                return _.reduce(curr.decls, function(acc, decl) {
+                    return acc.concat(decl.ident);
+                }, acc);
             };
             return acc;
         }, []);

--- a/src/expander.js
+++ b/src/expander.js
@@ -544,7 +544,9 @@
 
         return _.reduce(term.body.delim.token.inner, function(acc, curr) {
             if (curr.hasPrototype(VariableStatement)) {
-                return acc.concat(curr.decls[0].ident);
+                return _.reduce(curr.decls, function(acc, decl) {
+                    return acc.concat(decl.ident);
+                }, acc);
             };
             return acc;
         }, []);

--- a/test/test_macro_hygiene.js
+++ b/test/test_macro_hygiene.js
@@ -112,6 +112,28 @@ describe("macro hygiene", function() {
     expect(z).to.be(303);
   });
 
+  it("should work with a multiple declarations", function() {
+    var a = 10;
+    var b = 20;
+    macro main {
+      case () => {
+        (function() {
+          var a = 100, b = 200;
+          return sub();
+        })();
+      }
+    }
+    macro sub {
+      case () => {
+        a + b
+      }
+    }
+
+    var z = main();
+
+    expect(z).to.be(30);
+  });
+
   // it("should work for vars with hoisting", function() {
   //   macro m {
   //     case $x:lit => {


### PR DESCRIPTION
example:

``` js
var a = 10;
var b = 20;
macro main {
  case () => {
    (function() {
      var a = 100, b = 200;
      return sub();
    })();
  }
}
macro sub {
  case () => {
    a + b
  }
}

var z = main();

expect(z).to.be(30);
```

I expected 30. But returned 210. `b = 200` was not renamed.
