### PR TITLE
Use node plumbing to locate macro module.

### DIFF
--- a/src/sjs.js
+++ b/src/sjs.js
@@ -40,12 +40,20 @@ exports.run = function() {
     }
 
 
-    var module = argv.module;
-    var modulefile;
+    var mod = argv.module;
+    var cwd = process.cwd();
+    var Module = module.constructor;
+    var modulepath, modulefile, modulemock;
 
 
-    if(module) {
-        modulefile = fs.readFileSync(module, "utf8");
+    if(mod) {
+        modulemock = {
+          id: cwd + '/$sweet-loader.js',
+          filename: '$sweet-loader.js',
+          paths: /^\.\/|\.\./.test(cwd) ? [cwd] : Module._nodeModulePaths(cwd)
+        };
+        modulepath = Module._resolveFilename(mod, modulemock);
+        modulefile = fs.readFileSync(modulepath, "utf8");
         file = modulefile + "\n" + file;
     }
     


### PR DESCRIPTION
This is a change to the `sjs` binary that lets it load macros from installed modules, in addition to relative files, by piggybacking off of node's internal API for resolving module locations.

This is a bit hacky as node doesn't expose this API directly, but seeing as how node's module system is locked, I doubt it will be changing significantly any time soon.

If you provide a `--module` that starts with a `./` or `../` it will resolve it based on the cwd. If you provide it with a package name like `somelib/macros` it will walk up the `node_modules` tree.

Overall, a lot could be done to improve macro loading from packages, but I think this is a decent first step that doesn't require users to copy files around.
