### PR TITLE
Add comments to read tree.

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1200,7 +1200,7 @@
             throwError("Primitive macro form must contain a function for the macro body");
         }
 
-        var stub = parser.read("()")[0];
+        var stub = parser.read("()");
         stub[0].token.inner = body;
         var expanded = expand(stub, env, defscope, templateMap);
         expanded = expanded[0].destruct().concat(expanded[1].eof);
@@ -1517,7 +1517,7 @@
         var env = new Map();
         var params = [];
         if (builtinSource) {
-            var builtinRead = parser.read(builtinSource)[0];
+            var builtinRead = parser.read(builtinSource);
 
             builtinRead = [syn.makeIdent("module", null),
                             syn.makeDelim("{}", builtinRead, null)];
@@ -1573,6 +1573,12 @@
                                     ? stx.token.sm_endLineStart
                                     : stx.token.endLineStart)
                 }, exposed);
+                if (stx.token.leadingComments) {
+                    openParen.token.leadingComments = stx.token.leadingComments;
+                }
+                if (stx.token.trailingComments) {
+                    openParen.token.trailingComments = stx.token.trailingComments;
+                }
                 return acc
                     .concat(openParen)
                     .concat(flatten(exposed.token.inner))

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -84,8 +84,9 @@
     // (CSyntax, CSyntax) -> CSyntax
     function takeLine(from, to) {
         if (to.token.type === parser.Token.Delimiter) {
+            var next;
             if (from.token.type === parser.Token.Delimiter) {
-                var next = syntaxFromToken({
+                next = syntaxFromToken({
                     type: parser.Token.Delimiter,
                     value: to.token.value,
                     inner: to.token.inner,
@@ -98,7 +99,7 @@
                 }, to);
 
             } else {
-                var next = syntaxFromToken({
+                next = syntaxFromToken({
                     type: parser.Token.Delimiter,
                     value: to.token.value,
                     inner: to.token.inner,
@@ -110,26 +111,32 @@
                     endLineStart: from.token.lineStart
                 }, to);
             }
-            return next;
-        }
-
-        if (from.token.type === parser.Token.Delimiter) {
-            return syntaxFromToken({
-                value: to.token.value,
-                type: to.token.type,
-                lineNumber: from.token.startLineNumber,
-                lineStart: from.token.startLineStart,
-                range: from.token.startRange
-            }, to);
         } else {
-            return syntaxFromToken({
-                value: to.token.value,
-                type: to.token.type,
-                lineNumber: from.token.lineNumber,
-                lineStart: from.token.lineStart,
-                range: from.token.range
-            }, to);
+            if (from.token.type === parser.Token.Delimiter) {
+                next = syntaxFromToken({
+                    value: to.token.value,
+                    type: to.token.type,
+                    lineNumber: from.token.startLineNumber,
+                    lineStart: from.token.startLineStart,
+                    range: from.token.startRange
+                }, to);
+            } else {
+                next = syntaxFromToken({
+                    value: to.token.value,
+                    type: to.token.type,
+                    lineNumber: from.token.lineNumber,
+                    lineStart: from.token.lineStart,
+                    range: from.token.range,
+                }, to);
+            }
         }
+        if (to.token.leadingComments) {
+            next.token.leadingComments = to.token.leadingComments;
+        }
+        if (to.token.trailingComments) {
+            next.token.trailingComments = to.token.trailingComments;
+        }
+        return next;
     }
 
     function loadPattern(patterns) {

--- a/src/sweet.js
+++ b/src/sweet.js
@@ -80,7 +80,7 @@
 
         var readTree = parser.read(source);
         try {
-            return [expander.expand(readTree[0], stxcaseModule), readTree[1]];
+            return expander.expand(readTree, stxcaseModule);
         } catch(err) {
             if (err instanceof syn.MacroSyntaxError) {
                 throw new SyntaxError(syn.printSyntaxError(source, err));
@@ -97,9 +97,8 @@
             // and loc/range info so until we can upgrade hack in a single space
             code = " ";
         }
-        var exp = expand(code);
 
-        return parser.parse(exp[0], exp[1]);
+        return parser.parse(expand(code));
     }
 
     exports.expand = expand;
@@ -107,7 +106,6 @@
 
     exports.compileWithSourcemap = function(code, filename) {
         var ast = parse(code);
-        codegen.attachComments(ast, ast.comments, ast.tokens);
         var code_output = codegen.generate(ast, {
             comment: true
         });
@@ -121,7 +119,6 @@
 
     exports.compile = function compile(code) {
         var ast = parse(code);
-        codegen.attachComments(ast, ast.comments, ast.tokens);
         return codegen.generate(ast, {
             comment: true
         });

--- a/test/test_expander_units.js
+++ b/test/test_expander_units.js
@@ -27,21 +27,21 @@ var emptyMacroMap = new Map();
 
 describe("matchPatternClass", function() {
     it("should give null when pattern doesn't match", function() {
-        var stx = parser.read("42")[0];
+        var stx = parser.read("42");
         var res = matchPatternClass("ident", stx, emptyMacroMap).result;
 
         expect(res).to.be(null);
     });
 
     it("should match a single token", function() {
-        var stx = parser.read("foo bar")[0];
+        var stx = parser.read("foo bar");
         var res = matchPatternClass("token", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo"]);
     });
 
     it("should match a single delimited token", function() {
-        var stx = parser.read("(foo) bar")[0];
+        var stx = parser.read("(foo) bar");
         var res = matchPatternClass("token", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["(", "foo", ")"]);
@@ -49,189 +49,189 @@ describe("matchPatternClass", function() {
     });
 
     it("should match a lit", function() {
-        var stx = parser.read("42")[0];
+        var stx = parser.read("42");
         var res = matchPatternClass("lit", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([42]);
     });
 
     it("should match an ident", function() {
-        var stx = parser.read("foo")[0];
+        var stx = parser.read("foo");
         var res = matchPatternClass("ident", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo"]);
     });
 
     it("should match a unary expression", function() {
-        var stx = parser.read("+2")[0];
+        var stx = parser.read("+2");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["+", 2]);
     });
 
     it("should match a complex unary expression", function() {
-        var stx = parser.read("++2 + 42")[0];
+        var stx = parser.read("++2 + 42");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["++", 2, "+", 42]);
     });
 
     it("should match a postfix unary expression", function() {
-        var stx = parser.read("x++")[0];
+        var stx = parser.read("x++");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["x", "++"]);
     });
 
     it("should match a binary expression", function() {
-        var stx = parser.read("2+2")[0];
+        var stx = parser.read("2+2");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([2, "+", 2]);
     });
 
     it("should match a complex binary expression", function() {
-        var stx = parser.read("2+2*10/32")[0];
+        var stx = parser.read("2+2*10/32");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([2, "+", 2, "*", 10, "/", 32]);
     });
 
     it("should handle a broken binary expression", function() {
-        var stx = parser.read("2+2 + +")[0];
+        var stx = parser.read("2+2 + +");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([2, "+", 2]);
     });
 
     it("should handle a binary and unary expression", function() {
-        var stx = parser.read("2 + 2 - ++x")[0];
+        var stx = parser.read("2 + 2 - ++x");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([2, "+", 2, "-", "++", "x"]);
     });
 
     it("should match a this expression", function() {
-        var stx = parser.read("this.foo")[0];
+        var stx = parser.read("this.foo");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["this", ".", "foo"]);
     });
 
     it("should match a literal expression", function() {
-        var stx = parser.read("42")[0];
+        var stx = parser.read("42");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql([42]);
     });
 
     it("should match a parenthesized expression", function() {
-        var stx = parser.read("(42)")[0];
+        var stx = parser.read("(42)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["(", 42, ")"]);
     });
 
     it("should match an array literal", function() {
-        var stx = parser.read("[1,2,3]")[0];
+        var stx = parser.read("[1,2,3]");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["[", 1, ",", 2, ",", 3, "]"]);
     });
 
     it("should match a simple object literal", function() {
-        var stx = parser.read("{a: 42}")[0];
+        var stx = parser.read("{a: 42}");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["{", "a", ":", 42, "}"]);
     });
 
     it("should match an empty function call", function() {
-        var stx = parser.read("foo()")[0];
+        var stx = parser.read("foo()");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", "(", ")"]);
     });
 
     it("should match a simple function call", function() {
-        var stx = parser.read("foo(24)")[0];
+        var stx = parser.read("foo(24)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", "(", 24, ")"]);
     });
 
     it("should match a function call with two simple arguments", function() {
-        var stx = parser.read("foo(24, 42)")[0];
+        var stx = parser.read("foo(24, 42)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", "(", 24, ",", 42, ")"]);
     });
 
     it("should match a function call with two complex arguments", function() {
-        var stx = parser.read("foo(24 + 24, 42)")[0];
+        var stx = parser.read("foo(24 + 24, 42)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", "(", 24, "+", 24, ",", 42, ")"]);
     });
 
     it("should not match a function call with a non-expression as one of the args", function() {
-        var stx = parser.read("foo(24 + 24 +, 42)")[0];
+        var stx = parser.read("foo(24 + 24 +, 42)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo"]);
     });
 
     it("should not match a function call with a non-expression punctuator", function() {
-        var stx = parser.read("foo(24 + 24, ,)")[0];
+        var stx = parser.read("foo(24 + 24, ,)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo"]);
     });
 
     it("should match a simple dotted get", function() {
-        var stx = parser.read("foo.bar")[0];
+        var stx = parser.read("foo.bar");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", ".", "bar"]);
     });
 
     it("should match a dotted get method call", function() {
-        var stx = parser.read("foo.bar(f())")[0];
+        var stx = parser.read("foo.bar(f())");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["foo", ".", "bar", "(", "f", "(", ")", ")"]);
     });
 
     it("should match a new expression", function() {
-        var stx = parser.read("new Foo(42)")[0];
+        var stx = parser.read("new Foo(42)");
         var res = matchPatternClass("expr", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["new", "Foo", "(", 42, ")"]);
     });
 
     it("should match a simple var declaration statement", function() {
-        var stx = parser.read("var x")[0];
+        var stx = parser.read("var x");
         var res = matchPatternClass("VariableStatement", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["var", "x"]);
     });
 
     it("should match a var declaration statement with multiple decls", function() {
-        var stx = parser.read("var x, y, z")[0];
+        var stx = parser.read("var x, y, z");
         var res = matchPatternClass("VariableStatement", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["var", "x", ",", "y", ",", "z"]);
     });
 
     it("should match a var decl with simple init expr", function() {
-        var stx = parser.read("var x = 42")[0];
+        var stx = parser.read("var x = 42");
         var res = matchPatternClass("VariableStatement", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["var", "x", "=", 42]);
     });
 
     it("should match a var statement with multiple simple decls", function() {
-        var stx = parser.read("var x = 42, y = 24")[0];
+        var stx = parser.read("var x = 42, y = 24");
         var res = matchPatternClass("VariableStatement", stx, emptyMacroMap).result;
 
         expect(tokValues(res)).to.eql(["var", "x", "=", 42, ",", "y", "=", 24]);
@@ -241,26 +241,26 @@ describe("matchPatternClass", function() {
 
 describe("expand", function() {
     it("handle a simple binary expression", function() {
-        var stx = parser.read("42 + 24")[0];
+        var stx = parser.read("42 + 24");
         var res = (expander.expand(stx));
         expect(tokValues(res)).to.eql([42, "+", 24, '']);
     });
 
     it("should expand a complex binary expression", function() {
-        var stx = parser.read("1 + 2 * 3")[0];
+        var stx = parser.read("1 + 2 * 3");
         var res = (expander.expand(stx));
         expect(tokValues(res)).to.eql([1, "+", 2, "*", 3, '']);
     });
 
     it("should handle a simple object bracket get", function() {
-        var stx = parser.read("test[0]")[0];
+        var stx = parser.read("test[0]");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["test", "[", 0, "]", ""]);
     });
 
     it("should handle a object bracket get", function() {
-        var stx = parser.read("test[2+3-1]")[0];
+        var stx = parser.read("test[2+3-1]");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["test", "[", 2, "+", 3, "-", 1, "]", ""]);
@@ -268,21 +268,21 @@ describe("expand", function() {
 
 
     it("should handle a binop and an object bracket get", function() {
-        var stx = parser.read("42 == test[0]")[0];
+        var stx = parser.read("42 == test[0]");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql([42, "==", "test", "[", 0, "]", ""]);
     });
 
     it("should handle function calls", function() {
-        var stx = parser.read("foo(24, 42)")[0];
+        var stx = parser.read("foo(24, 42)");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["foo", "(", "24", ",", "42", ")", ""]);
     });
 
     it("should handle get/call/binop/parens", function() {
-        var stx = parser.read("(x.foo(0) >= 42) || (x === 42)")[0];
+        var stx = parser.read("(x.foo(0) >= 42) || (x === 42)");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["(", "x", ".", "foo", "(", 0, ")", 
@@ -290,7 +290,7 @@ describe("expand", function() {
     });
 
     it("should handle complex left side function calls", function() {
-        var stx = parser.read("(function(x) { return x; })(24)")[0];
+        var stx = parser.read("(function(x) { return x; })(24)");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["(", "function", "(", "x", ")", "{", 
@@ -299,7 +299,7 @@ describe("expand", function() {
     });    
 
     it("should match a var statement with multiple complex decls", function() {
-        var stx = parser.read("var x = (function(x) { return x; })(24), y = 2 + 4")[0];
+        var stx = parser.read("var x = (function(x) { return x; })(24), y = 2 + 4");
         var res = (expander.expand(stx));
 
         expect(tokValues(res)).to.eql(["var", "x", "=", "(", "function", "(", "x", ")",
@@ -309,7 +309,7 @@ describe("expand", function() {
 
 
     it("should throw an error for with statements", function() {
-        var stx = parser.read("with ({}) {}")[0];
+        var stx = parser.read("with ({}) {}");
 
         expect(function() { expander.expand(stx);}).to.throwError();
     });

--- a/test/test_reader.js
+++ b/test/test_reader.js
@@ -8,7 +8,7 @@ var _ = require("underscore");
 var Token = parser.Token;
 
 var read = _.wrap(parser.read, function(read_func, read_arg) {
-    return syn.syntaxToTokens(read_func(read_arg)[0]);
+    return syn.syntaxToTokens(read_func(read_arg));
 });
 
 describe("reader", function() {
@@ -427,6 +427,18 @@ describe("reader", function() {
     it('should read / following a for( ; function(){ /a/g; } /a/g; ){} as a divide', function() {
         expect(read("for( ; function(){ /a/g; } /a/g; ){}")[1].inner[4].type)
             .to.be(Token.Punctuator);
+    });
+
+    it('should read line comments', function() {
+        var stx = read("//foo\nbar;");
+        expect(stx[0].leadingComments[0].type).to.be("Line");
+        expect(stx[0].leadingComments[0].value).to.be("foo");
+    });
+
+    it('should read block comments', function() {
+        var stx = read("/*foo*/\nbar;");
+        expect(stx[0].leadingComments[0].type).to.be("Block");
+        expect(stx[0].leadingComments[0].value).to.be("foo");
     });
 
 });


### PR DESCRIPTION
I tried to touch the parser as little as possible, so `scanComments/skipComments` still calls `addComments` which in turn adds it to `extra.comments`. `readToken` checks the diff on the length and adds the most recent comments to the token. If you'd like me to factor this out in a different way that doesn't rely on `extra.comments`, I can, but that might extend into more parts of the parser.

I also went ahead and changed the return type of `read` to just return the tree now, since returning comments also seemed superfluous. This propagated to all the tests.

There are a couple points to consider before a merge:
- Comments are only printed in the final source if the token survives expansion, so you can get into a situation where you might comment a statement that starts with a macro invocation. The macro name won't survive and the comment will be lost. Should we copy over the comment on the macro name to the first token in the expanded code, or just defer to macro writers to implement this if they want it?
- I'm not sure what you want to do with `takeLine`. I added code to copy over comments because otherwise no comments where propagated to the final tree, but I don't know exactly where `takeLine` is called and if it could result in duplicated comments in some instances.
