### PR TITLE
separate function args with commas in syntax-case macros (fixes #143)

### DIFF
--- a/macros/stxcase.js
+++ b/macros/stxcase.js
@@ -290,7 +290,9 @@ let syntaxCase = macro {
 
         var res = [
             makeDelim("()", makeFunc([makeIdent("stx", name_stx),
+                                      makePunc(",", name_stx),
                                       makeIdent("context", name_stx),
+                                      makePunc(",", name_stx),
                                       makeIdent("parentMatch", name_stx)], body),
                       name_stx),
             makeDelim("()", arg_stx.concat([
@@ -388,7 +390,8 @@ let macro = macro {
             ? [takeLine(name_stx, makeIdent("macro", null)), mac_name_stx]
             : [takeLine(name_stx, makeIdent("macro", null))];
         res = res.concat(makeDelim("{}", makeFunc([makeIdent("stx", name_stx),
-                                                    makeIdent("context", name_stx)],
+                                                   makePunc(",", name_stx),
+                                                   makeIdent("context", name_stx)],
                                                    [makeIdent("return", name_stx),
                                                     makeIdent("syntaxCase", name_stx),
                                                     makeDelim("()", [makeIdent("stx", name_stx),


### PR DESCRIPTION
Everything still seems to compile after I added the commas. I have no idea how it was working before, unless another macro was matching on the generated source, but I would think this would break it then... but it seems to all work well, and fixes my issue in #143
