### PR TITLE
Actually match literally in literal groups

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -157,6 +157,17 @@
         return next;
     }
 
+    function loadLiteralGroup(patterns) {
+        _.forEach(patterns, function(patStx) {
+            if (patStx.token.type === parser.Token.Delimiter) {
+                patStx.token.inner = loadLiteralGroup(patStx.token.inner);
+            } else {
+                patStx.class = "pattern_literal";
+            }
+        });
+        return patterns;
+    }
+
     function loadPattern(patterns) {
 
         return _.chain(patterns)
@@ -197,7 +208,13 @@
                     if (last && last.token.value === "$") {
                         patStx.class = "pattern_group";
                     }
-                    patStx.token.inner = loadPattern(patStx.token.inner);
+
+                    // Leave literal groups as is
+                    if (patStx.class === "pattern_group" && patStx.token.value === '[]') {
+                        patStx.token.inner = loadLiteralGroup(patStx.token.inner);
+                    } else {
+                        patStx.token.inner = loadPattern(patStx.token.inner);
+                    }
                 } else {
                     patStx.class = "pattern_literal";
                 }

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -648,4 +648,21 @@ describe("macro expander", function() {
         expect(x).to.be(42);
     });
 
+    it("should match tokens as is in literal groups", function() {
+        let m = macro {
+            rule { $a $[...] $b } => {
+                $a + $b
+            }
+            rule { $[$a:expr] } => {
+                "class"
+            }
+            rule { $[$[]] } => {
+                "literal group"
+            }
+        }
+        expect(m 42 ... 12).to.be(54);
+        expect(m $a:expr).to.be("class");
+        expect(m $[]).to.be("literal group");
+    });
+
 });


### PR DESCRIPTION
This is a fix for #142. Literal groups were not actually doing anything, as they were just run through `loadPattern` again. This adds a helper function called `loadLiteralGroup` which just marks everything as a `pattern_literal`.
