### PR TITLE
Cache op term on syntax object when enforesting rhs

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1118,8 +1118,13 @@
                         var op = rest[0];
                         var left = head;
                         var rightStx = rest.slice(1);
+
+                        // Reference the term on the syntax object for lookbehind.
+                        var bopPuncTerm = Punc.create(op);
+                        op.term = bopPuncTerm;
+
                         var bopPrevStx = getHeadStx(toks, rightStx).reverse().concat(prevStx);
-                        var bopPrevTerms = [Punc.create(rest[0]), head].concat(prevTerms);
+                        var bopPrevTerms = [bopPuncTerm, head].concat(prevTerms);
                         var bopRes = enforest(rightStx, context, bopPrevStx, bopPrevTerms);
 
                         // Lookbehind was matched, so it may not even be a binop anymore.
@@ -1137,6 +1142,9 @@
 
                     // UnaryOp (via punctuation)
                     Punc(punc) | (stxIsUnaryOp(punc)) => {
+                        // Reference the term on the syntax object for lookbehind.
+                        head.punc.term = head;
+
                         var unopPrevStx = [punc].concat(prevStx);
                         var unopPrevTerms = [head].concat(prevTerms);
                         var unopRes = enforest(rest, context, unopPrevStx, unopPrevTerms);
@@ -1154,6 +1162,9 @@
 
                     // UnaryOp (via keyword)
                     Keyword(keyword) | (stxIsUnaryOp(keyword)) => {
+                        // Reference the term on the syntax object for lookbehind.
+                        head.keyword.term = head;
+
                         var unopKeyPrevStx = [keyword].concat(prevStx);
                         var unopKeyPrevTerms = [head].concat(prevTerms);
                         var unopKeyres = enforest(rest, context, unopKeyPrevStx, unopKeyPrevTerms);

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -771,6 +771,19 @@ describe("macro expander", function() {
         expect(delete m 2).to.be(4);
     });
 
+    it("should not raise an assertion when the rhs has a pattern class and the syntax is an op", function() {
+        macro m {
+            rule infix { $lhs:expr | $rhs:expr } => {
+                $lhs + $rhs
+            }
+            rule infix { $lhs | $rhs } => {
+                $lhs $rhs
+            }
+        }
+        expect(1 m 2).to.be(3);
+        expect(typeof m 2).to.be('number');
+    });
+
     it("should allow infix matching of repeaters", function() {
         macro m {
             rule infix { $num ... | } => {


### PR DESCRIPTION
There was a bug in infix matching when a macro immediately follows an operator and tries to match the lhs with an `expr` class. Lookbehind matching requires the term be tagged to the syntax object so it can check for term splitting and so it doesn't have to try and reenforest an expression. The term was not being tagged on the temporary term for the operator when enforesting a `BinaryOp` and `UnaryOp`.
