### PR TITLE
Support thin arrow syntax in macros

### DIFF
--- a/browser/scripts/parser.js
+++ b/browser/scripts/parser.js
@@ -760,7 +760,7 @@ parseYieldExpression: true
                 ]
             };
         }
-        if (ch1$1291 === '=' && ch2$1292 === '>') {
+        if ((ch1$1291 === '=' || ch1$1291 === '-') && ch2$1292 === '>') {
             index$1090 += 2;
             return {
                 type: Token$1079.Punctuator,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -760,7 +760,7 @@ parseYieldExpression: true
                 ]
             };
         }
-        if (ch1$1291 === '=' && ch2$1292 === '>') {
+        if ((ch1$1291 === '=' || ch1$1291 === '-') && ch2$1292 === '>') {
             index$1090 += 2;
             return {
                 type: Token$1079.Punctuator,

--- a/src/parser.js
+++ b/src/parser.js
@@ -790,7 +790,7 @@ parseYieldExpression: true
             };
         }
 
-        if (ch1 === '=' && ch2 === '>') {
+        if ((ch1 === '=' || ch1 === '-') && ch2 === '>') {
             index += 2;
             return {
                 type: Token.Punctuator,


### PR DESCRIPTION
It seems like `=>` is hardcoded; at least for the moment, I'd love for `->` thin arrow syntax to land also when infix operators are announced.
