### PR TITLE
Add missing globalMacros to compile call in sjs.js

### DIFF
--- a/src/sjs.js
+++ b/src/sjs.js
@@ -100,7 +100,7 @@ exports.run = function() {
                              "utf8");
             fs.writeFileSync(outfile + ".map", result.sourceMap, "utf8");
         } else {
-            fs.writeFileSync(outfile, sweet.compile(file).code, "utf8");
+            fs.writeFileSync(outfile, sweet.compile(file, {macros: globalMacros}).code, "utf8");
         }
     } else if (tokens) {
         console.log(sweet.expand(file, globalMacros, numexpands));


### PR DESCRIPTION
When used with both -m and -o arguments, e.g.

```
sjs -m bar.sjs -o foo.js foo.sjs
```

the modules were being ignored. This commit fixes this.
