### PR TITLE
Allow macros to override binary and postfix ops.

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1113,6 +1113,13 @@
 
                     // BinOp
                     Expr(emp) | (rest[0] && rest[1] && stxIsBinOp(rest[0])) => {
+                        // Check if the operator is a macro first.
+                        if (context.env.has(resolve(rest[0]))) {
+                            var headStx = tagWithTerm(head, head.destruct().reverse());
+                            prevStx = headStx.concat(prevStx);
+                            prevTerms = [head].concat(prevTerms);
+                            return step(rest[0], rest.slice(1));
+                        }
                         var op = rest[0];
                         var left = head;
                         var rightStx = rest.slice(1);
@@ -1176,6 +1183,13 @@
                     // Postfix
                     Expr(emp) | (rest[0] && (unwrapSyntax(rest[0]) === "++" || 
                                             unwrapSyntax(rest[0]) === "--")) => {
+                        // Check if the operator is a macro first.
+                        if (context.env.has(resolve(rest[0]))) {
+                            var headStx = tagWithTerm(head, head.destruct().reverse());
+                            prevStx = headStx.concat(prevStx);
+                            prevTerms = [head].concat(prevTerms);
+                            return step(rest[0], rest.slice(1));
+                        }
                         return step(PostfixOp.create(head, rest[0]), rest.slice(1));
                     }
 
@@ -1524,6 +1538,13 @@
         return next;
     }
 
+    function tagWithTerm(term, stx) {
+        _.forEach(stx, function(s) {
+            s.term = term;
+        });
+        return stx;
+    }
+
 
     // mark each syntax object in the pattern environment,
     // mutating the environment
@@ -1712,10 +1733,7 @@
 
         // We build the newPrevTerms/Stx here (instead of at the beginning) so
         // that macro definitions don't get added to it.
-        var destructed = f.result.destruct();
-        destructed.forEach(function(stx) {
-            stx.term = head;
-        });
+        var destructed = tagWithTerm(head, f.result.destruct());
         var newPrevTerms = [head].concat(f.prevTerms);
         var newPrevStx = destructed.reverse().concat(f.prevStx);
 
@@ -1777,9 +1795,7 @@
                     var bodyEnf = enforest(rest, context);
                     var bodyDestructed = bodyEnf.result.destruct();
                     var renamedBodyTerm = bodyEnf.result.rename(letId, letNew);
-                    bodyDestructed.forEach(function(stx) {
-                        stx.term = renamedBodyTerm;
-                    });
+                    tagWithTerm(renamedBodyTerm, bodyDestructed);
                     return expandToTermTree(bodyEnf.rest, 
                                             context,
                                             bodyDestructed.reverse().concat(newPrevStx),

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -802,4 +802,24 @@ describe("macro expander", function() {
         expect(3, 2, 1 m).to.be(0)
     });
 
+    it("should allow macros to override binary operators", function() {
+        macro + {
+            rule infix { $lhs:expr | $rhs:expr } => {
+                $lhs - $rhs
+            }
+        }
+        expect(3 + 2 + 1).to.be(0)
+    })
+
+    it("should allow macros to override postfix operators", function() {
+        macro ++ {
+            rule infix { $lhs:expr | } => {
+                $lhs--
+            }
+        }
+        var a = 1;
+        a++;
+        expect(a).to.be(0)
+    })
+
 });


### PR DESCRIPTION
This fixes a bug with infix macros where you couldn't override native operators in binop and postfix position.
