### PR TITLE
Only reverse top-level repeater matches

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -396,7 +396,7 @@
                     if (restMatch.success) {
                         // match the repeat pattern on the empty array to fill in its
                         // pattern variable in the environment 
-                        match = matchPattern(pattern, [], env, patternEnv);
+                        match = matchPattern(pattern, [], env, patternEnv, topLevel);
                         patternEnv = _.extend(restMatch.patternEnv, match.patternEnv);
                         rest = restMatch.rest;
                         break patternLoop;
@@ -416,7 +416,7 @@
                         }
                     }
                 }
-                match = matchPattern(pattern, rest, env, patternEnv);
+                match = matchPattern(pattern, rest, env, patternEnv, topLevel);
                 if (!match.success && pattern.repeat) {
                     // a repeat can match zero tokens and still be a
                     // "success" so break out of the inner loop and
@@ -514,7 +514,7 @@
         "$y" : ...
     }
     */
-    function matchPattern(pattern, stx, env, patternEnv) {
+    function matchPattern(pattern, stx, env, patternEnv, topLevel) {
         var subMatch;
         var match, matchEnv;
         var rest;
@@ -562,7 +562,8 @@
                         // initialize if we haven't done so already
                         patternEnv[patternKey] = {
                             level: nextLevel,
-                            match: [subMatch.patternEnv[patternKey]]
+                            match: [subMatch.patternEnv[patternKey]],
+                            topLevel: topLevel
                         };
                     }
                 } else {
@@ -592,7 +593,8 @@
                 rest = match.rest;
                 matchEnv = {
                     level: 0,
-                    match: match.result
+                    match: match.result,
+                    topLevel: topLevel
                 };
 
                 // push the match onto this value's slot in the environment
@@ -603,7 +605,8 @@
                         // initialize if necessary
                         patternEnv[pattern.value] = {
                             level: 1,
-                            match: [matchEnv]
+                            match: [matchEnv],
+                            topLevel: topLevel
                         };
                     }
                 } else {
@@ -658,7 +661,7 @@
         // We need to reverse the matches for any top level repeaters because
         // they match in reverse, and thus put their results in backwards.
         _.forEach(patternEnv, function(val, key) {
-            if (val.level && val.match) {
+            if (val.level && val.match && val.topLevel) {
                 val.match.reverse();
             }
         });

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -844,4 +844,14 @@ describe("macro expander", function() {
         expect(a).to.be(0)
     })
 
+    it("should only reverse top-level repeater patterns", function() {
+        macro m {
+            rule infix { ($num ...) | } => {
+                $num (-) ...
+            }
+        }
+
+        expect((3 2 1) m).to.be(0);
+    })
+
 });


### PR DESCRIPTION
When matching on lookbehind, repeater vars go in reversed, which we have to correct. Previously it was doing it for all `level: 1` matches, but what we actually need is to do it for `topLevel` patterns. This adds a `topLevel` key to match objects so we can make the distinction.
