### PR TITLE
Allow infix matching when building ObjectGet terms

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1234,8 +1234,26 @@
 
                     // ObjectGet
                     Expr(emp) | (rest[0] && unwrapSyntax(rest[0]) === "." &&
+                                 !context.env.has(resolve(rest[0])) &&
                                  rest[1] &&
                                  rest[1].token.type === parser.Token.Identifier) => {
+                        // Check if the identifier is a macro first.
+                        if (context.env.has(resolve(rest[1]))) {
+                            var headStx = tagWithTerm(head, head.destruct().reverse());
+                            var dotTerm = Punc.create(rest[0]);
+                            var dotTerms = [dotTerm].concat(head, prevTerms);
+                            var dotStx = tagWithTerm(dotTerm, [rest[0]]).concat(headStx, prevStx);
+                            var dotRes = enforest(rest.slice(1), context, dotStx, dotTerms);
+
+                            if (dotRes.prevTerms.length < dotTerms.length) {
+                                return dotRes;
+                            } else {
+                                return step(head,
+                                            [rest[0]].concat(dotRes.result.destruct(), dotRes.rest),
+                                            prevStx,
+                                            prevTerms);
+                            }
+                        }
                         return step(ObjDotGet.create(head, rest[0], rest[1]),
                                     rest.slice(2));
                     }

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -831,7 +831,7 @@ describe("macro expander", function() {
             }
         }
         expect(3 + 2 + 1).to.be(0)
-    })
+    });
 
     it("should allow macros to override postfix operators", function() {
         macro ++ {
@@ -842,6 +842,39 @@ describe("macro expander", function() {
         var a = 1;
         a++;
         expect(a).to.be(0)
+    });
+
+    it("should allow infix matching of object dot", function() {
+        macro m {
+            rule infix { $lhs:ident . | } => {
+                $lhs
+            }
+        }
+
+        macro m2 {
+            rule { $tok } => {
+                $tok
+            }
+        }
+
+        var a = 42;
+        expect(a.m).to.be(42);
+
+        var b = { foo: 42 };
+        expect(b.m2 foo).to.be(42);
+    })
+
+    it("should allow a dot as a macro after an expression", function() {
+        let . = macro {
+            rule infix { foo | } => {
+                42
+            }
+            rule {} => { . }
+        }
+
+        var a = { foo: 12 };
+        expect(a.foo).to.be(12);
+        expect(foo.).to.be(42);
     })
 
 });


### PR DESCRIPTION
This is similar to what we have to do with operators.
