### PR TITLE
Maintain hygiene when combining let and ASI

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1630,7 +1630,11 @@
             }
         }
 
-        while (next.rest.length) {
+        while (next.rest.length &&
+               context.env.has(resolve(next.rest[0])) &&
+               tokenValuesArePrefix(context.env.get(resolve(next.rest[0])).fullName,
+                                    next.rest)) {
+
             // Enforest the next term tree since it might be an infix macro that
             // consumes the initial expression.
             peek = enforest(next.rest, context, next.result.destruct(), [next.result]);
@@ -1644,7 +1648,7 @@
 
             // No new expression was created, so we've reached the end.
             if (peek.result === next.result) {
-                break;
+                return peek;
             }
 
             // A new expression was created, so loop back around and keep going.

--- a/test/test_enforest.js
+++ b/test/test_enforest.js
@@ -32,5 +32,17 @@ describe("enforest", function() {
         var res = enforest(read("var x, y"), makeExpanderContext());
         expect(res.result.decls.length).to.be(2);
     });
+
+    // Currently disabled because it requires --harmony mode
+    // it("should maintain let hygiene when enforesting an expression with ASI", function() {
+    //     'use strict';
+    //     let a = 1 // No semicolons
+    //     let b = 2 
+    //     function test() {
+    //         // If the bug is present, this is a ReferenceError
+    //         return b;
+    //     }
+    //     expect(test()).to.be(2);
+    // });
 });
 


### PR DESCRIPTION
#207

To elaborate: In order to use an infix macro, like `a => a + 1` where `=>` is the macro, we have to be greedy about enforesting expressions in `get_expression`. The first `a` is an expression itself, but what the user intuitively wants is for the whole thing to be a single expression. So we have to try enforesting the next token afterwards, and see if it extends the original expression. With semicolons, it just gets a punctuator back and stops. Without the semicolon, it hits another `const` which kicks off a nested call to `enforestVarStatement` which kicks off let renaming. It then gets back to the original `get_expression` and it decides it has not extended the original expression. So in my example in #207, the `bar` const is actually enforested twice. Once to see if it extends `1` as an expression, and again afterwards.

The problem results from `get_expression`. When we get to the end, we need to return the `peek` which contains the correctly renamed `rest`, instead of just returning `next`. It's very subtle. I also put a guard on the loop to only keep enforesting if the next token is a macro. All we are looking for is to see if the next token is a macro that extends the expression, so it's guarding what we are looking for anyway.
