### PR TITLE
Refactor letstx

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -855,6 +855,12 @@
             }, []).value();
     }
 
+    function extendEnv(env) {
+        var newEnv = _.clone(env);
+        newEnv.parent = env;
+        return newEnv;
+    }
+
     exports.loadPattern = loadPattern;
     exports.matchPatterns = matchPatterns;
     exports.matchLookbehind = matchLookbehind;
@@ -863,4 +869,5 @@
     exports.takeLineContext = takeLineContext;
     exports.takeLine = takeLine;
     exports.typeIsLiteral = typeIsLiteral;
+    exports.extendEnv = extendEnv;
 }))

--- a/test/test_macro_case.js
+++ b/test/test_macro_case.js
@@ -201,6 +201,54 @@ describe "procedural (syntax-case) macros" {
         expect(l 5).to.be(65);
     }
 
+    it "should handle letstx within a loop" {
+        let l = macro {
+            case {_ $x } => {
+                var res = [];
+                var i = 3;
+                while (i--) {
+                    letstx $y = [makeValue(i + 1, #{here})];
+                    res = res.concat(#{ $y });
+                }
+                letstx $ys ... = res;
+                return #{
+                    $x - $ys (-) ...
+                }
+            }
+        }
+        expect(l 6).to.be(0);
+    }
+
+    it "should handle letstx with shadowed pattern vars" {
+        let l = macro {
+            case {_ $x } => {
+                var res;
+                if (true) {
+                    letstx $x = [makeValue(100, #{here})];
+                    res = #{ $x + };
+                }
+                return res.concat(#{ $x });
+            }
+        }
+        expect(l 42).to.be(142);
+    }
+
+    it "should handle letstx with sparse declarations" {
+        let l = macro {
+            case {_ $x } => {
+                var res;
+                if (true) {
+                    letstx $x = [makeValue(100, #{here})];
+                    1; 2; 3;
+                    letstx $y = [makeValue(50, #{here})];
+                    res = #{ $x + $y + };
+                }
+                return res.concat(#{ $x });
+            }
+        }
+        expect(l 42).to.be(192);
+    }
+
     it "should handle getExpr" {
         let m = macro {
             case {_ ($e ...) } => {


### PR DESCRIPTION
Fixes #215

This is a complete rewrite of `letstx` that handles all sorts of edge cases. The primary problem with the previous `letstx` was that it immediately called `return` which means it couldn't be used in branches or loops. This rewrite avoids `withSyntax` and `syntaxCase` completely, and has a much simpler expansion. It mimics how `let` scope works, and can shadow pattern vars within an inner block without it affecting the outer pattern scope. The rewrite also has a nice consequence of allowing you to load multiple tokens into a pattern var without having to use a repeater, which is far more intuitive. Loading repeaters is still supported though for when you need it.

`withSyntax` should be considered deprecated, and will likely be removed with the 0.5.0 bump.
