### PR TITLE
Localize require

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,16 @@ module.exports = function(grunt) {
                 flatten: true,
                 src: "build/lib/*.js",
                 dest: "lib/"
+            },
+
+            testFixtures: {
+                expand: true,
+                flatten: false,
+                cwd: "test/",
+                src: "fixtures/**",
+                dest: "build/"
             }
+
         },
         mochaTest: {
             test: {
@@ -139,12 +148,17 @@ module.exports = function(grunt) {
 
     grunt.registerTask("dist", ["build:sweetjs", "copy:dist"]);
 
+    grunt.registerTask("test", ["build:test",
+                                "copy:testFixtures",
+                                "mochaTest"]);
+
     grunt.registerTask("default", ["copy:scopedEval",
                                    "copy:buildMacros",
                                    "build",
                                    "copy:browserSrc",
                                    "copy:browserMacros",
                                    "copy:scopedEvalBrowser",
+                                   "copy:testFixtures",
                                    "mochaTest",
                                    "jshint"]);
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "optimist": "~0.3.4",
     "underscore": "~1.3.3",
     "escodegen": "1.1.x",
-    "escope": "1.0.x"
+    "escope": "1.0.x",
+    "resolve": "~0.6.1"
   },
   "devDependencies": {
     "mocha": "~1.3.2",

--- a/src/expander.js
+++ b/src/expander.js
@@ -1771,6 +1771,12 @@
             makeKeyword: syn.makeKeyword,
             makePunc: syn.makePunc,
             makeDelim: syn.makeDelim,
+            require: function(id) {
+                if (context.requireModule) {
+                    return context.requireModule(id, context.filename);
+                }
+                return require(id);
+            },
             getExpr: function(stx) {
                 var r;
                 if (stx.length === 0) {
@@ -2179,6 +2185,10 @@
         o = o || {};
         // read-only but can enumerate
         return Object.create(Object.prototype, {
+            filename: {value: o.filename,
+                       writable: false, enumerable: true, configurable: false},
+            requireModule: {value: o.requireModule,
+                            writable: false, enumerable: true, configurable: false},
             env: {value: o.env || new StringMap(),
                   writable: false, enumerable: true, configurable: false},
             defscope: {value: o.defscope,
@@ -2190,13 +2200,22 @@
         });
     }
 
+    function makeTopLevelExpanderContext(options) {
+        var requireModule = options ? options.requireModule : undefined;
+        var filename = options ? options.filename : undefined;
+        return makeExpanderContext({
+            filename: filename,
+            requireModule: requireModule
+        });
+    }
+
     // a hack to make the top level hygiene work out
-    function expandTopLevel(stx, moduleContexts, _maxExpands) {
+    function expandTopLevel(stx, moduleContexts, options) {
         moduleContexts = moduleContexts || [];
-        maxExpands = _maxExpands || Infinity;
+        maxExpands = (_.isNumber(options) ? options : options && options._maxExpands) || Infinity;
         expandCount = 0;
 
-        var context = makeExpanderContext();
+        var context = makeTopLevelExpanderContext(options);
         var modBody = syn.makeDelim("{}", stx, null);
         modBody = _.reduce(moduleContexts, function(acc, mod) {
             context.env.extend(mod.env);
@@ -2208,12 +2227,12 @@
         return flatten(res[0].token.inner);
     }
 
-    function expandModule(stx, moduleContexts) {
+    function expandModule(stx, moduleContexts, options) {
         moduleContexts = moduleContexts || [];
         maxExpands = Infinity;
         expandCount = 0;
 
-        var context = makeExpanderContext();
+        var context = makeTopLevelExpanderContext(options);
         var modBody = syn.makeDelim("{}", stx, null);
         modBody = _.reduce(moduleContexts, function(acc, mod) {
             context.env.extend(mod.env);

--- a/src/sweet.js
+++ b/src/sweet.js
@@ -25,11 +25,26 @@
 
 (function (root, factory) {
     if (typeof exports === 'object') {
-        var path = require('path');
-        var fs   = require('fs');
+        var path        = require('path');
+        var fs          = require('fs');
+        var resolveSync = require('resolve/lib/sync');
+
         var lib  = path.join(path.dirname(fs.realpathSync(__filename)), "../macros");
 
         var stxcaseModule = fs.readFileSync(lib + "/stxcase.js", 'utf8');
+
+        var moduleCache = {};
+        var cwd = process.cwd();
+
+        var requireModule = function(id, filename) {
+            var basedir = filename ? path.dirname(filename) : cwd;
+            var key = basedir + id;
+
+            if (!moduleCache[key]) {
+                moduleCache[key] = require(resolveSync(id, {basedir: basedir}));
+            }
+            return moduleCache[key];
+        }
 
         factory(exports,
                 require("underscore"),
@@ -39,7 +54,10 @@
                 stxcaseModule,
                 require("escodegen"),
                 require("escope"),
-                fs);
+                fs,
+                path,
+                resolveSync,
+                requireModule);
 
         // Alow require('./example') for an example.sjs file.
         require.extensions['.sjs'] = function(module, filename) {
@@ -55,7 +73,7 @@
                 './syntax',
                 'text!./stxcase.js'], factory);
     }
-}(this, function (exports, _, parser, expander, syn, stxcaseModule, gen, scope, fs) {
+}(this, function (exports, _, parser, expander, syn, stxcaseModule, gen, scope, fs, path, resolveSync, requireModule) {
     var codegen = gen || escodegen;
     var escope = scope || escope;
     var expand = makeExpand(expander.expand);
@@ -64,7 +82,7 @@
 
     function makeExpand(expandFn) {
         // fun (Str) -> [...CSyntax]
-        return function expand(code, modules, maxExpands) {
+        return function expand(code, modules, options) {
             var program, toString;
             modules = modules || [];
 
@@ -97,7 +115,7 @@
 
             var readTree = parser.read(source);
             try {
-                return expandFn(readTree, [stxcaseCtx].concat(modules), maxExpands);
+                return expandFn(readTree, [stxcaseCtx].concat(modules), options);
             } catch(err) {
                 if (err instanceof syn.MacroSyntaxError) {
                     throw new SyntaxError(syn.printSyntaxError(source, err));
@@ -109,14 +127,14 @@
     }
 
     // fun (Str, {}) -> AST
-    function parse(code, modules, maxExpands) {
+    function parse(code, modules, options) {
         if (code === "") {
             // old version of esprima doesn't play nice with the empty string
             // and loc/range info so until we can upgrade hack in a single space
             code = " ";
         }
 
-        return parser.parse(expand(code, modules, maxExpands));
+        return parser.parse(expand(code, modules, options));
     }
 
     // (Str, {sourceMap: ?Bool, filename: ?Str})
@@ -124,10 +142,11 @@
     function compile(code, options) {
         var output;
         options = options || {};
+        options.requireModule = options.requireModule || requireModule;
 
         var ast = parse(code, 
                         options.modules || [],
-                        options.maxExpands);
+                        options);
 
         if (options.readableNames) {
             ast = optimizeHygiene(ast);
@@ -156,15 +175,16 @@
         };
     }
 
-    function loadNodeModule(root, moduleName) {
-        var Module = module.constructor;
-        var mock = {
-            id: root + "/$sweet-loader.js",
-            filename: "$sweet-loader.js",
-            paths: /^\.\/|\.\./.test(root) ? [root] : Module._nodeModulePaths(root)
-        };
-        var path = Module._resolveFilename(moduleName, mock);
-        return expandModule(fs.readFileSync(path, "utf8"));
+    function loadNodeModule(root, moduleName, options) {
+        options = options || {};
+        if (moduleName[0] === '.') {
+            moduleName = path.resolve(root, moduleName)
+        }
+        var filename = resolveSync(moduleName, {basedir: root});
+        return expandModule(fs.readFileSync(filename, "utf8"), undefined, {
+            filename: moduleName,
+            requireModule: options.requireModule || requireModule
+        });
     }
 
     function optimizeHygiene(ast) {

--- a/test/fixtures/test_require/macro-module.sjs
+++ b/test/fixtures/test_require/macro-module.sjs
@@ -1,0 +1,8 @@
+macro m {
+  case { _ } => {
+    require("./module");
+    return [];
+  }
+}
+
+export m;

--- a/test/fixtures/test_require/module.js
+++ b/test/fixtures/test_require/module.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/test_require.js
+++ b/test/test_require.js
@@ -1,0 +1,27 @@
+var expect = require("expect.js");
+var sweet = require("../build/lib/sweet.js");
+
+describe('loading code from inside macros in Node.js', function() {
+
+  it('loads code from macros defined in top level module', function() {
+    var code = (
+      'macro m {' +
+      '  case { _ } => {' +
+      '    require("./fixtures/test_require/module");' +
+      '    return [];' +
+      '  }' +
+      '}' +
+      '' +
+      'm'
+    );
+    expect(sweet.compile.bind(null, code, {filename: __filename}))
+      .to.not.throwException();
+  });
+
+  it('loads code from macros defined in imported module', function() {
+    var code = 'm';
+    var mod = sweet.loadNodeModule(__dirname, './fixtures/test_require/macro-module.sjs');
+    expect(sweet.compile.bind(null, code, {modules: [mod]}))
+      .to.not.throwException();
+  });
+});


### PR DESCRIPTION
Make require inside scopedEval to resolve modules againt current module's
filename. This way we can require functions from other modules.

Allows to do `require(...)` calls inside macro bodies:

```
macro sql {
  case { _ $expr:expr } => {
    var parser = require('sql-parser');
    return parser.parse(#{$expr}.token.value);
  } 
}
```

This is very useful when you want to embed some other language inside JS (via ES6 tagged template strings for example), see [sweet-jsx](https://github.com/andreypopp/sweet-jsx/blob/master/example.sjs) or [sweet-sql](https://github.com/andreypopp/sweet-sql/blob/master/examples.sjs) for example.
