### PR TITLE
load escope when using requirejs

### DIFF
--- a/src/sweet.js
+++ b/src/sweet.js
@@ -53,7 +53,9 @@
                 './parser',
                 './expander',
                 './syntax',
-                'text!./stxcase.js'], factory);
+                'text!./stxcase.js',
+                null,
+                './escope'], factory);
     }
 }(this, function (exports, _, parser, expander, syn, stxcaseModule, gen, scope, fs) {
     var codegen = gen || escodegen;


### PR DESCRIPTION
The requirejs usage wasn't updated for `readableNames`. For some reason I can't load `escodegen` like this, but if I pass null it seems to work... I'm open to figuring out why that is.
