### PR TITLE
Add shorthand withSyntax form

### DIFF
--- a/macros/stxcase.js
+++ b/macros/stxcase.js
@@ -672,6 +672,16 @@ let withSyntax = macro {
             withSyntax_unzip $name () () ($vars ...) {$body ...}
         }
     }
+    case { $name ($vars ...) #{$body ...} } => {
+        var here = #{ here };
+        return #{
+            withSyntax_unzip $name () () ($vars ...)
+        }.concat(makeDelim("{}", [
+            makeKeyword("return", here),
+            makePunc("#", #{ $name }),
+            makeDelim("{}", #{$body ...}, here)
+        ], here));
+    }
 }
 
 export withSyntax;

--- a/test/test_macro_case.js
+++ b/test/test_macro_case.js
@@ -106,6 +106,17 @@ describe "procedural (syntax-case) macros" {
         }
         expect(m 5).to.be(65);
     }
+
+    it "should support shorthand withSyntax form" {
+        macro m {
+            case {_ $x } => {
+                return withSyntax($y = [makeValue(42, #{here})]) #{
+                    $x + $y
+                }
+            }
+        }
+        expect(m 100).to.be(142);
+    }
     
     it "should support let bound macros" {
         let m = macro {


### PR DESCRIPTION
99% of the time you don't need to put more JS within `withSyntax`. This adds a shorthand form where the body is just a syntax quote.
