### PR TITLE
Add global macros array for node loader.

### DIFF
--- a/browser/scripts/sweet.js
+++ b/browser/scripts/sweet.js
@@ -43,7 +43,7 @@
         // Alow require('./example') for an example.sjs file.
         require.extensions['.sjs'] = function (module, filename) {
             var content = require('fs').readFileSync(filename, 'utf8');
-            module._compile(codegen.generate(exports.parse(content)), filename);
+            module._compile(codegen.generate(exports.parse(content, exports.loadedMacros)), filename);
         };
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -223,10 +223,18 @@
         });
         return ast;
     }
+    var loadedMacros = [];
+    // syntax sugar for
+    // sweet.loadedMacros.push(sweet.loadNodeModule(process.cwd(), './macros/str'));
+    function loadMacro(relative_file) {
+        loadedMacros.push(loadNodeModule(process.cwd(), relative_file));
+    }
     exports$2.expand = expand;
     exports$2.parse = parse;
     exports$2.compile = compile;
     exports$2.loadModule = expandModule;
     exports$2.loadNodeModule = loadNodeModule;
+    exports$2.loadedMacros = loadedMacros;
+    exports$2.loadMacro = loadMacro;
 }));
 //# sourceMappingURL=sweet.js.map

--- a/lib/sweet.js
+++ b/lib/sweet.js
@@ -43,7 +43,7 @@
         // Alow require('./example') for an example.sjs file.
         require.extensions['.sjs'] = function (module, filename) {
             var content = require('fs').readFileSync(filename, 'utf8');
-            module._compile(codegen.generate(exports.parse(content)), filename);
+            module._compile(codegen.generate(exports.parse(content, exports.loadedMacros)), filename);
         };
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -223,10 +223,18 @@
         });
         return ast;
     }
+    var loadedMacros = [];
+    // syntax sugar for
+    // sweet.loadedMacros.push(sweet.loadNodeModule(process.cwd(), './macros/str'));
+    function loadMacro(relative_file) {
+        loadedMacros.push(loadNodeModule(process.cwd(), relative_file));
+    }
     exports$2.expand = expand;
     exports$2.parse = parse;
     exports$2.compile = compile;
     exports$2.loadModule = expandModule;
     exports$2.loadNodeModule = loadNodeModule;
+    exports$2.loadedMacros = loadedMacros;
+    exports$2.loadMacro = loadMacro;
 }));
 //# sourceMappingURL=sweet.js.map

--- a/src/sweet.js
+++ b/src/sweet.js
@@ -63,7 +63,7 @@
         // Alow require('./example') for an example.sjs file.
         require.extensions['.sjs'] = function(module, filename) {
             var content = require('fs').readFileSync(filename, 'utf8');
-            module._compile(codegen.generate(exports.parse(content)), filename);
+            module._compile(codegen.generate(exports.parse(content, exports.loadedMacros)), filename);
         };
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -271,11 +271,21 @@
         return ast;
     }
 
+    var loadedMacros = [];
+
+    // syntax sugar for
+    // sweet.loadedMacros.push(sweet.loadNodeModule(process.cwd(), './macros/str'));
+    function loadMacro (relative_file) {
+      loadedMacros.push(loadNodeModule(process.cwd(), relative_file));
+    }
+
     exports.expand = expand;
     exports.parse = parse;
     exports.compile = compile;
     exports.loadModule = expandModule;
     exports.loadNodeModule = loadNodeModule;
+    exports.loadedMacros = loadedMacros;
+    exports.loadMacro = loadMacro;
 }));
 
 


### PR DESCRIPTION
For my opened issue #294:

`sweet.loadedMacros` - array of macros used with node-loader.
`sweet.loadMacro(file)` - helper to load macros. Same as `sweet.loadedMacros.push(sweet.loadNodeModule(process.cwd(), './macros/str'))`

Example:

``` js
var sweet = require('sweet.js');
sweet.loadMacro('./macros/str');
require('./test.sjs');
```

Note: it doesn't work if we load macros inside executing file and use in same file

``` js
sweet.loadMacro('./macros/puts');
puts 123; // not working
```
