### PR TITLE
Add bare bones `localExpand`

### DIFF
--- a/test/test_macro_case.js
+++ b/test/test_macro_case.js
@@ -283,4 +283,18 @@ describe "procedural (syntax-case) macros" {
         expect(m ()).to.be(100);
     }
 
+    it "should handle localExpand" {
+        let m = macro {
+            case {_ ($e ...) } => {
+                var e = localExpand(#{$e ...});
+                if (unwrapSyntax(e[0]) === 42) {
+                    return #{true}
+                }
+                return #{false}
+            }
+        }
+        let id = macro { rule { $x } => { $x } }
+        expect(m (id 42)).to.be(true);
+    }
+
 }


### PR DESCRIPTION
This is a simple implementation of local expansion. It currently does not support stop lists, but fully expands the syntax given to it. I wanted to get something in we can experiment with so we can figure out how best to implement stop lists/patterns.

Does the hygiene look correct?
