### PR TITLE
Fix pattern for multiple where bindings in macroclass

### DIFF
--- a/macros/stxcase.js
+++ b/macros/stxcase.js
@@ -799,12 +799,22 @@ macro make_pattern {
     }
 }
 
-macro patt {
-    rule { pattern { $patt ... } where ($($lhs ... = $rhs ...) (,) ...) }
-      => { ($patt ...) ($((($lhs ...) ($rhs ...))) ...) }
+macro where_binding {
+    rule { $lhs ... = $rhs ... , } => {
+        (($lhs ...) ($rhs ...))
+    }
+    rule { $lhs ... = $rhs ... } => {
+        (($lhs ...) ($rhs ...))
+    }
+}
 
-    rule { pattern { $patt ... } }
-      => { ($patt ...) () }
+macro patt {
+    rule { pattern { $patt ... } where ($wheres:where_binding ...) } => {
+      ($patt ...) ($wheres ...)
+    }
+    rule { pattern { $patt ... } } => {
+      ($patt ...) ()
+    }
 }
 
 


### PR DESCRIPTION
`macroclass` only allowed one binding in a `where` clause due to a bad pattern.
