### PR TITLE
Allow transcription of empty higher-level repeaters

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -771,7 +771,7 @@
         if (m.level === 0) {
             return m.match.length > 0;
         }
-        return m.match.every(function(m) { return hasMatch(m); });
+        return !!m.match;
     }
 
     // given the given the macroBody (list of Pattern syntax objects) and the

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -1039,4 +1039,17 @@ describe("macro expander", function() {
         expect((m (1==1)) ? (m x) : (m y)).to.be(x);
         expect((m (1!=1)) ? (m x) : (m y)).to.be(y);
     });
+
+    it("should allow transcription of empty higher-level repeaters", function() {
+        function a(){ return 1; }
+        function b(){ return 2; }
+        macro m {
+            rule { ($($name ($args (,) ...)) (,) ...) } => {
+                [$($name($args (,) ...)) (,) ...];
+            }
+        }
+        var res = m(a(1, 2), b());
+        expect(res[0]).to.be(1);
+        expect(res[1]).to.be(2);
+    });
 });


### PR DESCRIPTION
Fixes #315

I think this is correct. If the level is 0 (non-repeater) it must have a non-empty match. If it is a repeater, its ok for it to be empty.
