### PR TITLE
Fix nested multi-token macros in delims

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -847,7 +847,9 @@
                 (next.token.type === parser.Token.Punctuator ||
                  next.token.type === parser.Token.Identifier ||
                  next.token.type === parser.Token.Keyword) &&
-                curr.token.range[1] === next.token.range[0]) {
+                 (curr.token.sm_range && next.token.sm_range &&
+                  curr.token.sm_range[1] === next.token.sm_range[0] ||
+                  curr.token.range[1] === next.token.range[0])) {
                 name.push(next);
                 curr = next;
                 next = rest[++idx];

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -744,7 +744,18 @@ describe("macro expander", function() {
         }
 
         expect(:= 100).to.be(100);
-    })
+    });
+
+    it("should work with nested multi token macro names", function() {
+        let (->) = macro {
+            rule infix { $arg:ident | $body:expr } => {
+                function($arg) { return $body }
+            }
+        }
+
+        var fn = x -> [y -> x + y];
+        expect(fn(1)[0](3)).to.be(4);
+    });
 
     it("should allow macros to override binary operators", function() {
         macro + {


### PR DESCRIPTION
Fixes #313

`getName` was checking just the range, which gets clobbered, so the tokens end up getting the exact same range. I've changed it to check `sm_range` first which has the original location.
