### PR TITLE
Allow 1 non-expression infix match in expression position

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1669,8 +1669,9 @@
             }
 
             // Potentially an infix macro
-            if (head.isExpr && rest.length &&
-                nameInEnv(rest[0], rest.slice(1), context.env)) {
+            // This should only be invoked on runtime syntax terms
+            if (!head.isMacro && !head.isLetMacro && !head.isAnonMacro && !head.isOperatorDefinition &&
+                rest.length && nameInEnv(rest[0], rest.slice(1), context.env)) {
                 var infLeftTerm = opCtx.prevTerms[0] && opCtx.prevTerms[0].isPartial
                                   ? opCtx.prevTerms[0]
                                   : null;

--- a/test/test_infix.js
+++ b/test/test_infix.js
@@ -148,4 +148,14 @@ describe("infix macros", function() {
         expect(f()).to.be(42);
     });
 
+    it("should allow infix matching on 1 non-expr term in expression position", function() {
+        macro m {
+            rule infix { for | $x } => {
+                $x
+            }
+        }
+        var a = for m 42;
+        expect(a).to.be(42);
+    });
+
 });


### PR DESCRIPTION
At least partially fixes #327

It's still limited to 1 term infix match, but that solves a lot of use cases.
