### PR TITLE
make suppressReadError more aggressive

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -5567,9 +5567,8 @@ parseYieldExpression: true
             return func();
         }
         catch(e) {
-            var msg = e.message.toLowerCase();
-            if (msg.indexOf('unexpected token') !== -1 ||
-                msg.indexOf('assert') !== -1) {
+            if(!(e instanceof SyntaxError) &&
+               !(e instanceof TypeError)) {
                 restoreParserState(prevState);
                 return null;
             }


### PR DESCRIPTION
Just a small tweak that makes `suppressReadError` do more of a blacklisting rather than whitelisting. There's no common error class so I can't really check if the error came from reading. This will supress all errors that aren't basic `TypeError` or `SyntaxError`. That is helpful in case someone finds a real internal parser bug, which will be thrown instead of suppressed.
