### PR TITLE
fix sourcemaps when macro is expanded on line 0

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -2563,13 +2563,13 @@
                 acc.push(closeParen);
                 return acc;
             }
-            stx.token.sm_lineNumber = stx.token.sm_lineNumber
+            stx.token.sm_lineNumber = typeof stx.token.sm_lineNumber != 'undefined'
                                     ? stx.token.sm_lineNumber
                                     : stx.token.lineNumber;
-            stx.token.sm_lineStart = stx.token.sm_lineStart
+            stx.token.sm_lineStart = typeof stx.token.sm_lineStart != 'undefined'
                                     ? stx.token.sm_lineStart
                                     : stx.token.lineStart;
-            stx.token.sm_range = stx.token.sm_range
+            stx.token.sm_range = typeof stx.token.sm_range != 'undefined'
                                     ? stx.token.sm_range
                                     : stx.token.range;
             acc.push(stx);


### PR DESCRIPTION
If you are generating a sourcemap and a macro expansion occurs on line 0 (at least in some cases), right now you get an "invalid source mapping" error. This fixes that. Sorry I don't have an exact test case right now... want me to add one? I guess it would be good to add to the tests.
