### PR TITLE
allow yield* as a unary operator (fixes #372)

### DIFF
--- a/src/expander.js
+++ b/src/expander.js
@@ -1070,6 +1070,11 @@
                         uopMacroName = [uopSyntax].concat(rest.slice(0, uopMacroObj.fullName.length - 1));
                         opRest = rest.slice(uopMacroObj.fullName.length - 1);
                     }
+                    else if(unwrapSyntax(uopSyntax) === 'yield' &&
+                            unwrapSyntax(opRest[0]) === '*') {
+                        uopSyntax = [uopSyntax, opRest[0]];
+                        opRest = opRest.slice(1);
+                    }
 
                     var leftLeft = opCtx.prevTerms[0] && opCtx.prevTerms[0].isPartial
                                    ? opCtx.prevTerms[0]


### PR DESCRIPTION
Continuing discussion from #372, @natefaubion I think we need to support `yield*` as a unary operator globally for now. We should file a bug for the edge case where we aren't in a generator, but it's a much bigger issue now that you can't use `yield*` at all. This is really easy to do, so I say we do it.
