### PR TITLE
Fix empty trailing macroclass in delimiters

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -437,8 +437,8 @@
                 result = [syntax.makeDelim("()", result, result[0])];
                 rest = match.rest;
             }
-        } else if (stx.length > 0 && (patternObj.class === "invoke" ||
-                                      patternObj.class === "invokeRec")) {
+        } else if (patternObj.class === "invoke" ||
+                   patternObj.class === "invokeRec") {
             match = expandWithMacro(patternObj.macroName, stx, context,
                                     patternObj.class === "invokeRec");
             result = match.result;

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -1151,5 +1151,15 @@ describe("macro expander", function() {
             42;
         }
         expect(foo()).to.be(undefined);
-    })
+    });
+
+    it("should allow empty trailing macroclasses in delimiters", function() {
+        macroclass foo {
+            rule {}
+        }
+        macro m {
+            rule { (1 2 $x:foo) } => { true }
+        }
+        expect(m(1 2)).to.be(true);
+    });
 });


### PR DESCRIPTION
Fixes bug brought up in #384
