### PR TITLE
Adds cwd value to gruntfile's copy:dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,8 @@ module.exports = function(grunt) {
 
             dist: {
                 expand: true,
-                src: "build/lib/**/*.js",
+                cwd: "build/lib/",
+                src: "**/*.js",
                 dest: "lib/"
             },
             testFixtures: {


### PR DESCRIPTION
Adds cwd value so grunt copies the files in build/lib/*_/_ to lib/ instead of lib/build/lib. Unfortunately, running `grunt dist` after this fails with:

```
Running "build:release" (build) task
compiling src/data/env.js
compiling src/data/stringMap.js
compiling src/data/termTree.js
compiling src/data/transforms.js
compiling src/expander.js
Warning: Line 565: Illegal newline after throw
[... else { throw e ; } ...] Use --force to continue.

Aborted due to warnings.
```
