### PR TITLE
Temporarily disable ambiguous scopesets error

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -430,25 +430,26 @@ export default class Syntax {
           })
           .sort(sizeDecending);
 
-        if (
-          biggestBindingPair.size >= 2 &&
-          biggestBindingPair.get(0).scopes.size ===
-            biggestBindingPair.get(1).scopes.size
-        ) {
-          let debugBase =
-            '{' + stxScopes.map(s => s.toString()).join(', ') + '}';
-          let debugAmbigousScopesets = biggestBindingPair
-            .map(({ scopes }) => {
-              return '{' + scopes.map(s => s.toString()).join(', ') + '}';
-            })
-            .join(', ');
-          throw new Error(
-            'Scopeset ' +
-              debugBase +
-              ' has ambiguous subsets ' +
-              debugAmbigousScopesets,
-          );
-        } else if (biggestBindingPair.size !== 0) {
+        // if (
+        //   biggestBindingPair.size >= 2 &&
+        //   biggestBindingPair.get(0).scopes.size ===
+        //     biggestBindingPair.get(1).scopes.size
+        // ) {
+        //   let debugBase =
+        //     '{' + stxScopes.map(s => s.toString()).join(', ') + '}';
+        //   let debugAmbigousScopesets = biggestBindingPair
+        //     .map(({ scopes }) => {
+        //       return '{' + scopes.map(s => s.toString()).join(', ') + '}';
+        //     })
+        //     .join(', ');
+        //   throw new Error(
+        //     'Scopeset ' +
+        //       debugBase +
+        //       ' has ambiguous subsets ' +
+        //       debugAmbigousScopesets,
+        //   );
+        // } else
+        if (biggestBindingPair.size !== 0) {
           let bindingStr = biggestBindingPair.get(0).binding.toString();
           if (Maybe.isJust(biggestBindingPair.get(0).alias)) {
             // null never happens because we just checked if it is a Just

--- a/test/unit/test-modules.js
+++ b/test/unit/test-modules.js
@@ -256,6 +256,31 @@ test(
   true,
 );
 
+test(
+  'using helpers in a chain works',
+  evalWithStore,
+  {
+    './helpers.js': helperSrc,
+    a: `
+      'lang sweet.js';
+      import { isKeyword } from './helpers.js' for syntax;
+      export syntax m = ctx => {
+        let n = ctx.next().value;
+        if (isKeyword(n)) {
+          return #\`true\`;
+        }
+        return #\`false\`;
+      }
+    `,
+    'main.js': `
+      'lang sweet.js';
+      import { m } from 'a';
+      output = m foo;
+    `,
+  },
+  false,
+);
+
 // test('importing a chain for syntax works', evalWithStore, {
 //   'b': `#lang 'sweet.js';
 //     export function b(x) { return x; }

--- a/test/unit/test-syntax.js
+++ b/test/unit/test-syntax.js
@@ -63,7 +63,7 @@ test('should resolve when syntax object has a scopeset that is a superset of the
   expect(foo_1.resolve(0)).to.be(foo_123.resolve(0));
 });
 
-test('should throw an error for ambiguous scops sets', () => {
+test.skip('should throw an error for ambiguous scops sets', () => {
   let bindings = new BindingMap();
   let scope1 = freshScope('1');
   let scope2 = freshScope('2');


### PR DESCRIPTION
Disabling this for now because the ambiguous scopeset error is being triggered in some basic cases where it should not (#693 in particular). Actually fixing the underlying hygiene bug requires a bit more thought and time. 

I think the real problem has to do with how the module inside edge scope is being added but it's going to take me a little while to work though how to fix it.