### PR TITLE
Throw when encountering an invalid identifier as the first char

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "no-console": ["warn"],
     "no-unused-vars": ["error", { "args": "none"}],
     "quotes": ["error", "single", { "allowTemplateLiterals": true}],
-    "object-curly-spacing": ["error", "always"]
+    "object-curly-spacing": ["error", "always"],
+    "flowtype/no-types-missing-file-annotation": "warn"
   }
 }

--- a/src/reader/utils.js
+++ b/src/reader/utils.js
@@ -13,7 +13,7 @@ import {
   isKeyword,
   isBraces,
   isParens,
-  isIdentifier,
+  isIdentifier
 } from '../tokens';
 
 const {
@@ -21,7 +21,7 @@ const {
   isWhiteSpace,
   isDecimalDigit,
   isIdentifierPartES6: isIdentifierPart,
-  isIdentifierStartES6: isIdentifierStart,
+  isIdentifierStartES6: isIdentifierStart
 } = code;
 
 import * as R from 'ramda';
@@ -36,7 +36,7 @@ export {
   isWhiteSpace,
   isDecimalDigit,
   isIdentifierStart,
-  isIdentifierPart,
+  isIdentifierPart
 };
 
 export function getHexValue(rune: string) {
@@ -114,7 +114,7 @@ export function readStringEscape(
   str: string,
   stream: CharStream,
   start: number,
-  octal: ?string,
+  octal: ?string
 ) {
   let idx = start + 1, char = stream.peek(idx), lineStart;
   if (isEOS(char)) throw this.createILLEGAL(char);
@@ -155,7 +155,7 @@ export function readStringEscape(
         }
         unescaped = char === 'u'
           ? scanUnicode.call(this, stream, idx)
-          : scanHexEscape2.call(this, stream);
+          : scanHexEscape2.call(this, stream, idx);
         if (unescaped === -1) throw this.createILLEGAL(char);
         idx = 0; // stream is read in scanUnicode and scanHexEscape2
 
@@ -170,7 +170,7 @@ export function readStringEscape(
             stream,
             char,
             idx,
-            octal,
+            octal
           );
         } else if (char === '8' || char === '9') {
           throw this.createILLEGAL(char);
@@ -221,13 +221,13 @@ function scanHexEscape2(stream, idx) {
 
   if (isEOS(char)) return -1;
 
-  let r1 = getHexValue(stream.peek());
+  let r1 = getHexValue(char);
   if (r1 === -1) return r1;
 
-  let r2 = getHexValue(stream.peek(1));
+  let r2 = getHexValue(stream.peek(idx + 1));
   if (r2 === -1) return r2;
 
-  stream.readString(2);
+  stream.readString(idx + 1);
   return (r1 << 4) | r2;
 }
 
@@ -252,7 +252,7 @@ export const isTerminating = (table: Readtable) => (char: string): boolean =>
 export function retrieveSequenceLength(
   table: Object,
   stream: CharStream,
-  idx: number,
+  idx: number
 ): number {
   const char = stream.peek(idx);
   if (!table[char]) {
@@ -276,7 +276,7 @@ const assignOps = [
   '&=',
   '|=',
   '^=',
-  ',',
+  ','
 ];
 
 const binaryOps = [
@@ -303,7 +303,7 @@ const binaryOps = [
   '>',
   '!=',
   '!==',
-  'instanceof',
+  'instanceof'
 ];
 
 const unaryOps = [
@@ -316,7 +316,7 @@ const unaryOps = [
   'typeof',
   'yield',
   'throw',
-  'new',
+  'new'
 ];
 
 const allOps = assignOps.concat(binaryOps).concat(unaryOps);
@@ -332,7 +332,7 @@ const exprPrefixKeywords = [
   'yield',
   'throw',
   'new',
-  'case',
+  'case'
 ];
 
 function isExprReturn(l: number, p: List<TokenTree>) {
@@ -341,7 +341,7 @@ function isExprReturn(l: number, p: List<TokenTree>) {
   return popRestMaybe(p)
     .map(
       ([retKwd, rest]) =>
-        isKeyword(retKwd, 'return') && getLineNumber(retKwd) === l,
+        isKeyword(retKwd, 'return') && getLineNumber(retKwd) === l
     )
     .getOrElse(false);
 }
@@ -429,7 +429,7 @@ function isTopStandaloneKeyword(prefix: List<TokenTree>) {
         return Maybe.maybe(
           true,
           dot => !isPunctuator(dot, '.'),
-          popMaybe(rest),
+          popMaybe(rest)
         );
       }
       return false;
@@ -441,14 +441,14 @@ function isTopParensWithKeyword(prefix: List<TokenTree>) {
   // P . t . t' . (T)  where t \not = "." and t' ∈ (Keyword \setminus LiteralKeyword)
   return popRestMaybe(prefix)
     .chain(
-      ([paren, rest]) => (isParens(paren) ? popRestMaybe(rest) : Nothing()),
+      ([paren, rest]) => (isParens(paren) ? popRestMaybe(rest) : Nothing())
     )
     .map(([kwd, rest]) => {
       if (isNonLiteralKeyword(kwd)) {
         return Maybe.maybe(
           true,
           dot => !isPunctuator(dot, '.'),
-          popMaybe(rest),
+          popMaybe(rest)
         );
       }
       return false;
@@ -467,7 +467,7 @@ function popRestMaybe(p: List<TokenTree>): Maybe<[TokenTree, List<TokenTree>]> {
 
 function isTopFunctionExpression(
   prefix: List<TokenTree>,
-  exprAllowed: boolean,
+  exprAllowed: boolean
 ) {
   // P . function^l . x? . () . {}     where isExprPrefix(P, b, l) = false
   return popRestMaybe(prefix)

--- a/test/parser/test-run-test262.js
+++ b/test/parser/test-run-test262.js
@@ -7,28 +7,20 @@ import NodeLoader from '../../src/node-loader';
 // TODO: make these pass
 const passExcluded = [
   // known problems with the reader
-  '1252.script.js',
-  '978.script.js',
+  '1252.script.js', // Invalid test. U+180e isn't considered whitespace anymore
+
+  // sweet doesn't currently support script tags
   '953.script.js',
   '952.script.js',
   '951.script.js',
-  '950.script.js',
   '949.script.js',
-  '947.script.js',
-  '669.script.js',
-  '582.script.js',
-  '348.script.js',
   '315.script.js',
-  '314.script.js',
   '311.script.js',
   '299.script.js',
-  '211.script.js',
-  '210.script.js',
   '1657.script.js',
   '1656.script.js',
   '1655.script.js',
   '1654.script.js',
-  '1328.script.js',
 
   '1057.module.js',
   '1116.module.js',
@@ -102,29 +94,10 @@ const passExcluded = [
   '538.script.js',
   '680.script.js',
   '681.script.js',
-  '995.script.js',
+  '995.script.js'
 ];
 
 const failExcluded = [
-  // these tests hang. reader?
-  '15.script.js',
-  '16.script.js',
-  '233.script.js',
-  '287.script.js',
-  '472.script.js',
-  '498.script.js',
-  '499.script.js',
-  '558.script.js',
-  '559.script.js',
-  '560.script.js',
-  '561.script.js',
-  '562.script.js',
-  '570.script.js',
-  '581.script.js',
-  '657.script.js',
-  '681.script.js',
-  '682.script.js',
-
   // TODO: remove the following three after transform destructuring refactor
   '160.script.js',
   '822.script.js',
@@ -431,7 +404,7 @@ const failExcluded = [
   '912.module.js',
   '913.module.js',
   '924.module.js',
-  '965.module.js',
+  '965.module.js'
 ];
 
 // eslint-disable-next-line no-unused-vars
@@ -682,7 +655,7 @@ const earlyExcluded = [
   '535.module.js',
   '536.module.js',
   '537.module.js',
-  '538.module.js',
+  '538.module.js'
 ];
 
 const PARSER_TEST_DIR = 'test262-parser-tests';
@@ -697,14 +670,14 @@ function mkTester(subdir, testDir) {
   function f(t, fname) {
     let result = compile(
       `./${testDir}/${subdir}/${fname}`,
-      new NodeLoader(__dirname),
+      new NodeLoader(__dirname)
     );
     t.not(result, null);
   }
   f.title = (title, fname, expected) => {
     let src = fs.readFileSync(
       `./test/parser/${testDir}/${subdir}/${fname}`,
-      'utf8',
+      'utf8'
     );
     return `${fname}:
 ${src}
@@ -716,13 +689,13 @@ ${src}
 function mkFailTester(subdir, testDir) {
   function f(t, fname) {
     t.throws(() =>
-      compile(`./${testDir}/${subdir}/${fname}`, new NodeLoader(__dirname)),
+      compile(`./${testDir}/${subdir}/${fname}`, new NodeLoader(__dirname))
     );
   }
   f.title = (title, fname, expected) => {
     let src = fs.readFileSync(
       `./test/parser/${testDir}/${subdir}/${fname}`,
-      'utf8',
+      'utf8'
     );
     return `${fname}:
 ${src}

--- a/test/unit/test-default-readtable.js
+++ b/test/unit/test-default-readtable.js
@@ -7,7 +7,7 @@ import read from '../../src/reader/token-reader';
 import {
   TokenType as TT,
   TokenClass as TC,
-  EmptyToken,
+  EmptyToken
 } from '../../src/tokens';
 
 function testParse(source, tst) {
@@ -36,7 +36,7 @@ test('should parse Unicode identifiers', t => {
         filename: '',
         line: 1,
         column: 1,
-        position: 0,
+        position: 0
       });
     });
   }
@@ -58,6 +58,12 @@ test('should parse Unicode identifiers', t => {
   testParseIdentifier('\\u0061a', 'aa');
 });
 
+test('should throw given invalid characters', t => {
+  const error = t.throws(() => read('∇'));
+
+  t.true(error.message.includes('Invalid or unexpected token'));
+});
+
 test('should parse keywords', t => {
   function testParseKeyword(source, id) {
     testParse(source, result => {
@@ -67,7 +73,7 @@ test('should parse keywords', t => {
         filename: '',
         line: 1,
         column: 1,
-        position: 0,
+        position: 0
       });
     });
   }
@@ -88,7 +94,7 @@ test('should parse punctuators', t => {
         filename: '',
         line: 1,
         column: 1,
-        position: 0,
+        position: 0
       });
     });
   }
@@ -401,14 +407,14 @@ test('should parse comments', t => {
   * multi
   * line
   * comment
-  */`,
+  */`
   );
 });
 
 test('should properly update location information', t => {
   function testLocationInfo(
     source,
-    { idx, size, line: expectedLine, column: expectedColumn },
+    { idx, size, line: expectedLine, column: expectedColumn }
   ) {
     let result = read(source);
     let { line, column } = result.get(idx).slice.startLocation;
@@ -428,12 +434,12 @@ test('should properly update location information', t => {
   * line
   * comment
   */b c`,
-    { idx: 2, size: 3, line: 8, column: 7 },
+    { idx: 2, size: 3, line: 8, column: 7 }
   );
   testLocationInfo('"a\\\nb c\\\n d f g" a', {
     idx: 1,
     size: 2,
     line: 3,
-    column: 9,
+    column: 9
   });
 });


### PR DESCRIPTION
Fixes #702.

This used to throw the reader into an infinite loop. It made several test262 tests unrunnable.