### PR TITLE
Fix missing export in compiled output

### DIFF
--- a/src/sweet-to-shift-reducer.js
+++ b/src/sweet-to-shift-reducer.js
@@ -105,4 +105,23 @@ export default class extends Term.CloneReducer {
       statements: s.statements.toArray().filter(notEmptyStatement)
     });
   }
+
+  reduceExportSpecifier(t: Term, s: { name?: any, exportedName: Syntax }) {
+    return new S.ExportSpecifier({
+      name: s.name != null ? s.name.resolve(0) : null,
+      exportedName: s.exportedName.resolve(0)
+    });
+  }
+
+  reduceExportFrom(
+    t: Term,
+    s: { moduleSpecifier?: Syntax, namedExports: List<S.ExportSpecifier> }
+  ) {
+    return new S.ExportFrom({
+      moduleSpecifier: s.moduleSpecifier != null
+        ? s.moduleSpecifier.val()
+        : null,
+      namedExports: s.namedExports.toArray()
+    });
+  }
 }

--- a/test/parser/__snapshots__/test-ast.js.snap
+++ b/test/parser/__snapshots__/test-ast.js.snap
@@ -22,3 +22,61 @@ Module {
   "type": "Module",
 }
 `;
+
+exports[`includes export declaration in AST 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    Export {
+      "declaration": VariableDeclaration {
+        "declarators": Array [
+          VariableDeclarator {
+            "binding": BindingIdentifier {
+              "loc": null,
+              "name": "x_0",
+              "type": "BindingIdentifier",
+            },
+            "init": LiteralNumericExpression {
+              "loc": null,
+              "type": "LiteralNumericExpression",
+              "value": 1,
+            },
+            "loc": null,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "kind": "var",
+        "loc": null,
+        "type": "VariableDeclaration",
+      },
+      "loc": null,
+      "type": "Export",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes export in AST 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    ExportFrom {
+      "loc": null,
+      "moduleSpecifier": null,
+      "namedExports": Array [
+        ExportSpecifier {
+          "exportedName": "b",
+          "loc": null,
+          "name": null,
+          "type": "ExportSpecifier",
+        },
+      ],
+      "type": "ExportFrom",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;

--- a/test/parser/test-ast.js
+++ b/test/parser/test-ast.js
@@ -16,3 +16,19 @@ test('does include the use strict directive in the AST', t => {
   `)
   );
 });
+
+test('includes export in AST', t => {
+  t.snapshot(
+    getAst(`
+    export { b }
+    `)
+  );
+});
+
+test('includes export declaration in AST', t => {
+  t.snapshot(
+    getAst(`
+    export var x = 1;
+    `)
+  );
+});


### PR DESCRIPTION
Export declarations were not being included in the compiled output due to a too aggressive approach to preparing modules for eval inside of sweet. The PR fixes that in a hacky way, the module handling stuff needs a rewrite.

Don't merge this just yet, I want to add a snapshot test as in #718 but need to figure out why travis is complaining first. 