### PR TITLE
Do not resolve exportedNames

### DIFF
--- a/src/sweet-to-shift-reducer.js
+++ b/src/sweet-to-shift-reducer.js
@@ -109,7 +109,7 @@ export default class extends Term.CloneReducer {
   reduceExportSpecifier(t: Term, s: { name?: any, exportedName: Syntax }) {
     return new S.ExportSpecifier({
       name: s.name != null ? s.name.resolve(0) : null,
-      exportedName: s.exportedName.resolve(0)
+      exportedName: s.exportedName.val()
     });
   }
 

--- a/test/parser/__snapshots__/test-ast.js.snap
+++ b/test/parser/__snapshots__/test-ast.js.snap
@@ -27,7 +27,7 @@ exports[`includes export declaration in AST 1`] = `
 Module {
   "directives": Array [],
   "items": Array [
-    Export {
+    VariableDeclarationStatement {
       "declaration": VariableDeclaration {
         "declarators": Array [
           VariableDeclarator {
@@ -50,7 +50,20 @@ Module {
         "type": "VariableDeclaration",
       },
       "loc": null,
-      "type": "Export",
+      "type": "VariableDeclarationStatement",
+    },
+    ExportFrom {
+      "loc": null,
+      "moduleSpecifier": null,
+      "namedExports": Array [
+        ExportSpecifier {
+          "exportedName": "x",
+          "loc": null,
+          "name": "x_0",
+          "type": "ExportSpecifier",
+        },
+      ],
+      "type": "ExportFrom",
     },
   ],
   "loc": null,
@@ -69,7 +82,30 @@ Module {
         ExportSpecifier {
           "exportedName": "b",
           "loc": null,
-          "name": null,
+          "name": "b",
+          "type": "ExportSpecifier",
+        },
+      ],
+      "type": "ExportFrom",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes export with renaming in AST 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    ExportFrom {
+      "loc": null,
+      "moduleSpecifier": null,
+      "namedExports": Array [
+        ExportSpecifier {
+          "exportedName": "c",
+          "loc": null,
+          "name": "b",
           "type": "ExportSpecifier",
         },
       ],

--- a/test/parser/test-ast.js
+++ b/test/parser/test-ast.js
@@ -25,6 +25,14 @@ test('includes export in AST', t => {
   );
 });
 
+test('includes export with renaming in AST', t => {
+  t.snapshot(
+    getAst(`
+    export { b as c}
+    `)
+  );
+});
+
 test('includes export declaration in AST', t => {
   t.snapshot(
     getAst(`


### PR DESCRIPTION
Fixes #722.

Compiling `export var x` now compiles to `var x_1; export { x_1 as x }`.