### PR TITLE
Keep imports for runtime values

### DIFF
--- a/src/sweet-module.js
+++ b/src/sweet-module.js
@@ -235,7 +235,7 @@ export default class SweetModule {
 
   parse() {
     return new T.Module({
-      items: this.items,
+      items: (this.imports: any).concat(this.items),
       directives: this.directives
       // $FlowFixMe: flow doesn't know about reduce yet
     }).reduce(new SweetToShiftReducer(0));

--- a/src/sweet-to-shift-reducer.js
+++ b/src/sweet-to-shift-reducer.js
@@ -96,8 +96,37 @@ export default class extends Term.CloneReducer {
     });
   }
 
-  reduceImport() {
-    return new S.EmptyStatement({});
+  reduceImportNamespace(
+    t: Term,
+    s: {
+      defaultBinding: S.BindingIdentifier,
+      moduleSpecifier: Syntax,
+      namespaceBinding: S.BindingIdentifier
+    }
+  ) {
+    if (s.forSyntax) {
+      return new S.EmptyStatement();
+    }
+    return t;
+  }
+
+  reduceImport(
+    t: Term,
+    s: {
+      defaultBinding: S.BindingIdentifier,
+      moduleSpecifier: Syntax,
+      namedImports: List<any>
+    }
+  ) {
+    if (s.forSyntax) {
+      return new S.EmptyStatement();
+    }
+    return new S.Import({
+      forSyntax: false,
+      defaultBinding: s.defaultBinding,
+      moduleSpecifier: s.moduleSpecifier.val(),
+      namedImports: s.namedImports.toArray()
+    });
   }
 
   reduceBlock(t: Term, s: { statements: List<any> }) {

--- a/src/token-expander.js
+++ b/src/token-expander.js
@@ -16,6 +16,14 @@ import Syntax from './syntax.js';
 import ScopeReducer from './scope-reducer';
 import ModuleVisitor, { bindImports } from './module-visitor';
 
+function isBoundToCompiletime(name, store) {
+  let resolvedName = name.resolve(0);
+  if (store.has(resolvedName)) {
+    return store.get(resolvedName) instanceof CompiletimeTransform;
+  }
+  return false;
+}
+
 // $FlowFixMe: flow doesn't know about the CloneReducer yet
 class RegisterBindingsReducer extends Term.CloneReducer {
   useScope: any;
@@ -29,7 +37,7 @@ class RegisterBindingsReducer extends Term.CloneReducer {
     phase: number,
     skipDup: boolean,
     bindings: any,
-    env: Env,
+    env: Env
   ) {
     super();
     this.useScope = useScope;
@@ -45,12 +53,12 @@ class RegisterBindingsReducer extends Term.CloneReducer {
     this.bindings.add(newName, {
       binding: newBinding,
       phase: this.phase,
-      skipDup: this.skipDup,
+      skipDup: this.skipDup
     });
     this.env.set(newBinding.toString(), new VarBindingTransform(newName));
     // $FlowFixMe: flow doesn't know about extend
     return t.extend({
-      name: newName,
+      name: newName
     });
   }
 }
@@ -78,13 +86,13 @@ class RegisterSyntaxBindingsReducer extends Term.CloneReducer {
     this.bindings.add(newName, {
       binding: newBinding,
       phase: this.phase,
-      skipDup: false,
+      skipDup: false
     });
     let resolvedName = newName.resolve(this.phase);
     this.env.set(resolvedName, new CompiletimeTransform(this.val));
     // $FlowFixMe: flow doesn't know about extend
     return t.extend({
-      name: newName,
+      name: newName
     });
   }
 }
@@ -113,7 +121,7 @@ export default class TokenExpander extends ASTDispatcher {
   expandVariableDeclarationStatement(term: S.VariableDeclarationStatement) {
     // $FlowFixMe: flow doesn't know about extend
     return term.extend({
-      declaration: this.registerVariableDeclaration(term.declaration),
+      declaration: this.registerVariableDeclaration(term.declaration)
     });
   }
 
@@ -131,19 +139,19 @@ export default class TokenExpander extends ASTDispatcher {
       mod = this.context.loader.get(
         path,
         this.context.phase + 1,
-        this.context.cwd,
+        this.context.cwd
       );
       this.context.store = visitor.visit(
         mod,
         this.context.phase + 1,
         this.context.store,
-        mod.path,
+        mod.path
       );
       this.context.store = visitor.invoke(
         mod,
         this.context.phase + 1,
         this.context.store,
-        mod.path,
+        mod.path
       );
     } else {
       mod = this.context.loader.get(path, this.context.phase, this.context.cwd);
@@ -151,10 +159,40 @@ export default class TokenExpander extends ASTDispatcher {
         mod,
         this.context.phase,
         this.context.store,
-        mod.path,
+        mod.path
       );
     }
     bindImports(term, mod, this.context.phase, this.context);
+    let defaultBinding = null;
+    let namedImports = List();
+    if (term.defaultBinding != null) {
+      if (!isBoundToCompiletime(term.defaultBinding.name, this.context.store)) {
+        defaultBinding = term.defaultBinding;
+      }
+    }
+    if (term instanceof S.Import) {
+      namedImports = term.namedImports.filter(
+        specifier =>
+          !isBoundToCompiletime(specifier.binding.name, this.context.store)
+      );
+      if (defaultBinding == null && namedImports.size === 0) {
+        return new S.EmptyStatement();
+      }
+      return new S.Import({
+        forSyntax: term.forSyntax,
+        moduleSpecifier: term.moduleSpecifier,
+        defaultBinding,
+        namedImports
+      });
+    } else if (term instanceof S.ImportNamespace) {
+      return new S.ImportNamespace({
+        forSyntax: term.forSyntax,
+        moduleSpecifier: term.moduleSpecifier,
+        defaultBinding,
+        namespaceBinding: term.namespaceBinding
+      });
+    }
+    // return a new import filtered to just the runtime imports
     return term;
   }
 
@@ -172,11 +210,11 @@ export default class TokenExpander extends ASTDispatcher {
       T.isClassDeclaration(term.declaration)
     ) {
       return term.extend({
-        declaration: this.registerFunctionOrClass(term.declaration),
+        declaration: this.registerFunctionOrClass(term.declaration)
       });
     } else if (T.isVariableDeclaration(term.declaration)) {
       return term.extend({
-        declaration: this.registerVariableDeclaration(term.declaration),
+        declaration: this.registerVariableDeclaration(term.declaration)
       });
     }
     return term;
@@ -188,10 +226,10 @@ export default class TokenExpander extends ASTDispatcher {
       this.context.phase,
       false,
       this.context.bindings,
-      this.context.env,
+      this.context.env
     );
     return term.extend({
-      name: term.name.reduce(red),
+      name: term.name.reduce(red)
     });
   }
 
@@ -208,14 +246,14 @@ export default class TokenExpander extends ASTDispatcher {
       this.context.phase,
       term.kind === 'var',
       this.context.bindings,
-      this.context.env,
+      this.context.env
     );
     return term.extend({
       declarators: term.declarators.map(decl => {
         return decl.extend({
-          binding: decl.binding.reduce(red),
+          binding: decl.binding.reduce(red)
         });
-      }),
+      })
     });
   }
 
@@ -228,7 +266,7 @@ export default class TokenExpander extends ASTDispatcher {
       let scope = freshScope('nonrec');
       let scopeReducer = new ScopeReducer(
         [{ scope: scope, phase: ALL_PHASES, flip: false }],
-        this.context.bindings,
+        this.context.bindings
       );
       term = term.extend({
         declarators: term.declarators.map(decl => {
@@ -236,23 +274,23 @@ export default class TokenExpander extends ASTDispatcher {
           let nameAdded = name.addScope(
             scope,
             this.context.bindings,
-            ALL_PHASES,
+            ALL_PHASES
           );
           let nameRemoved = name.removeScope(
             this.context.currentScope[this.context.currentScope.length - 1],
-            this.context.phase,
+            this.context.phase
           );
           let newBinding = gensym(name.val());
           this.context.bindings.addForward(
             nameAdded,
             nameRemoved,
             newBinding,
-            this.context.phase,
+            this.context.phase
           );
           return decl.extend({
-            init: decl.init.reduce(scopeReducer),
+            init: decl.init.reduce(scopeReducer)
           });
-        }),
+        })
       });
     }
     // for syntax declarations we need to load the compiletime value
@@ -266,16 +304,16 @@ export default class TokenExpander extends ASTDispatcher {
           _.merge(this.context, {
             phase: this.context.phase + 1,
             env: new Env(),
-            store: this.context.store,
-          }),
+            store: this.context.store
+          })
         );
 
         let init = syntaxExpander.expand(decl.init);
         let val = evalCompiletimeValue(
           init,
           _.merge(this.context, {
-            phase: this.context.phase + 1,
-          }),
+            phase: this.context.phase + 1
+          })
         );
         let red = new RegisterSyntaxBindingsReducer(
           this.context.useScope,
@@ -286,11 +324,11 @@ export default class TokenExpander extends ASTDispatcher {
             type: compiletimeType,
             prec: decl.prec == null ? void 0 : decl.prec.val(),
             assoc: decl.assoc == null ? void 0 : decl.assoc.val(),
-            f: val,
-          },
+            f: val
+          }
         );
         return decl.extend({ binding: decl.binding.reduce(red), init });
-      }),
+      })
     });
   }
 

--- a/test/parser/test-run-test262.js
+++ b/test/parser/test-run-test262.js
@@ -102,6 +102,17 @@ const failExcluded = [
   '822.script.js',
   '833.script.js',
 
+  '533.script.js',
+  '58.script.js',
+  '59.script.js',
+  '60.script.js',
+  '63.script.js',
+  '751.module.js',
+  '752.module.js',
+  '754.module.js',
+  '756.module.js',
+  '757.module.js',
+
   '0.script.js',
   '19.script.js',
   '22.script.js',


### PR DESCRIPTION
fixes #727

Imports for runtime values should no longer be dropped during codegen. This is a hacky fix but I've got a few yaks to go before we can do it the right way.