### PR TITLE
Handle forwarding bindings better

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sweet-js/core",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 1,
   "dependencies": {
     "@ava/babel-plugin-throws-helper": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jquery": "3.1.1",
     "nyc": "^6.0.0",
     "prettier": "^1.5.3",
+    "rimraf": "^2.6.1",
     "source-map": "~0.5.3",
     "source-map-support": "^0.4.0",
     "webpack": "^1.13.1"

--- a/src/sweet-loader.js
+++ b/src/sweet-loader.js
@@ -154,10 +154,18 @@ export default class SweetLoader {
   // skip instantiate
   compile(
     entryPath: string,
-    refererName?: string,
-    enforceLangPragma?: boolean = true,
+    {
+      refererName,
+      enforceLangPragma,
+      isEntrypoint,
+    }: {
+      refererName?: string,
+      enforceLangPragma: boolean,
+      isEntrypoint: boolean,
+    },
   ) {
     let metadata = {
+      isEntrypoint,
       enforceLangPragma,
       entryPath,
     };
@@ -168,7 +176,11 @@ export default class SweetLoader {
   }
 
   get(entryPath: string, entryPhase: number, refererName?: string) {
-    return this.compile(`${entryPath}:${entryPhase}`, refererName);
+    return this.compile(`${entryPath}:${entryPhase}`, {
+      refererName,
+      enforceLangPragma: true,
+      isEntrypoint: false,
+    });
   }
 
   read(source: string): List<Term> {
@@ -197,6 +209,7 @@ export default class SweetLoader {
       _.merge(this.context, {
         currentScope: [outScope, inScope],
         cwd: path,
+        isEntrypoint: metadata.isEntrypoint,
       }),
     );
     return new SweetModule(

--- a/src/sweet.js
+++ b/src/sweet.js
@@ -14,7 +14,11 @@ function compileModule(
   loader: SweetLoader,
   refererName?: string,
 ) {
-  return loader.compile(entryPath, refererName, false);
+  return loader.compile(entryPath, {
+    refererName,
+    enforceLangPragma: false,
+    isEntrypoint: true,
+  });
 }
 
 export function parse(

--- a/src/token-expander.js
+++ b/src/token-expander.js
@@ -14,15 +14,10 @@ import { ALL_PHASES } from './syntax';
 import ASTDispatcher from './ast-dispatcher';
 import Syntax from './syntax.js';
 import ScopeReducer from './scope-reducer';
-import ModuleVisitor, { bindImports } from './module-visitor';
-
-function isBoundToCompiletime(name, store) {
-  let resolvedName = name.resolve(0);
-  if (store.has(resolvedName)) {
-    return store.get(resolvedName) instanceof CompiletimeTransform;
-  }
-  return false;
-}
+import ModuleVisitor, {
+  bindImports,
+  isBoundToCompiletime,
+} from './module-visitor';
 
 // $FlowFixMe: flow doesn't know about the CloneReducer yet
 class RegisterBindingsReducer extends Term.CloneReducer {
@@ -162,7 +157,13 @@ export default class TokenExpander extends ASTDispatcher {
         mod.path,
       );
     }
-    bindImports(term, mod, this.context.phase, this.context);
+    bindImports(
+      term,
+      mod,
+      this.context.phase,
+      this.context,
+      this.context.isEntrypoint,
+    );
     let defaultBinding = null;
     let namedImports = List();
     if (term.defaultBinding != null) {

--- a/test/modules/_helpers.js
+++ b/test/modules/_helpers.js
@@ -1,0 +1,31 @@
+import { writeFileSync, mkdtempSync } from 'fs';
+import { execSync } from 'child_process';
+import { compile } from '../../src/sweet';
+import NodeLoader from '../../src/node-loader';
+import { sync as rimraf } from 'rimraf';
+
+// write each module to a temp dir, compile them with sweet,
+// compile with babel to get commonjs modules, then assert on
+// the console log in main.js
+export function compileToCjs(t, inputModules, expected) {
+  let tmp = mkdtempSync(`./`);
+  let loader = new NodeLoader(tmp);
+  for (let fname of Object.keys(inputModules)) {
+    let path = `${tmp}/${fname}`;
+    writeFileSync(path, inputModules[fname], 'utf8');
+    let outfile = compile(path, loader);
+    writeFileSync(`${tmp}/${fname}.esm`, outfile.code, 'utf8');
+    execSync(
+      `babel --out-file ${tmp}/${fname} ${tmp}/${fname}.esm --no-babelrc --plugins=transform-es2015-modules-commonjs`,
+    );
+  }
+  let result = execSync(`node ${tmp}/main.js`).toString().trim();
+  t.is(result, expected);
+  rimraf(tmp);
+}
+compileToCjs.title = (title, inputStore, expected) =>
+  `${title}
+${Array.from(Object.entries(inputStore))
+    .map(([modName, modSrc]) => `${modName}\n----\n${modSrc}\n----`)
+    .join('\n')}
+> ${expected}`;

--- a/test/modules/test-expanding-cjs.js
+++ b/test/modules/test-expanding-cjs.js
@@ -1,0 +1,43 @@
+import { compileToCjs } from './_helpers';
+import test from 'ava';
+
+test(
+  'exporting and importing a variable works',
+  compileToCjs,
+  {
+    'mod.js': `
+  'lang sweet.js';
+  export var x = 'foo';
+  `,
+
+    'main.js': `
+  'lang sweet.js';
+  import { x } from './mod.js';
+  console.log(x);
+  `,
+  },
+  'foo',
+);
+
+test(
+  'exporting and importing a name passing through macro expansion works',
+  compileToCjs,
+  {
+    'mod.js': `
+  'lang sweet.js';
+  syntax m = ctx => {
+    let first = ctx.next().value;
+    let second = ctx.next().value;
+    return #\`var \${first} = \${second}\`;
+  }  
+  export m x 'foo'
+  `,
+
+    'main.js': `
+  'lang sweet.js';
+  import { x } from './mod.js';
+  console.log(x);
+  `,
+  },
+  'foo',
+);


### PR DESCRIPTION
fixes #736

Turns out there was an even simpler repro:

```js
// mod.js
export var x = 1;

// main.js
import { x } from './mod.js';
```

The issue is the design of module hygiene assumes bundling of all the modules #662 and so sets up a forwarding binding for each imported name. This greatly simplifies module bundling (just emit each module and bindings take care of themselves) but since we don't have bundling yet we run into this problem.

The solution is a little hacky, only add forwarding bindings to import names when:

- not the entrypoint or
- importing for phase > 0 or
- importing a compiletime binding

Don't merge just yet, I still need to add tests.