### PR TITLE
Add parsing support for async/await

### DIFF
--- a/src/enforester.js
+++ b/src/enforester.js
@@ -2102,7 +2102,10 @@ export class Enforester {
       this.advance();
     }
 
-    if (this.isIdentifier(lookahead, 'async')) {
+    if (
+      this.isIdentifier(lookahead, 'async') &&
+      !this.isPunctuator(this.peek(1), ':')
+    ) {
       isAsync = true;
       this.advance();
     }

--- a/src/enforester.js
+++ b/src/enforester.js
@@ -1437,7 +1437,7 @@ export class Enforester {
       this.isPunctuator(this.peek(1), '=>') &&
       this.lineNumberEq(lookahead, this.peek(1))
     ) {
-      return this.enforestArrowExpression();
+      return this.enforestArrowExpression({ isAsync: false });
     }
 
     if (this.term === null && this.isSyntaxTemplate(lookahead)) {
@@ -1454,7 +1454,8 @@ export class Enforester {
     if (
       this.term === null &&
       (this.isKeyword(lookahead, 'this') ||
-        this.isIdentifier(lookahead) ||
+        (this.isIdentifier(lookahead) &&
+          !this.isIdentifier(lookahead, 'await')) ||
         this.isKeyword(lookahead, 'let') ||
         this.isKeyword(lookahead, 'yield') ||
         this.isNumericLiteral(lookahead) ||

--- a/src/env.js
+++ b/src/env.js
@@ -26,6 +26,8 @@ import {
   ThrowTransform,
   NewTransform,
   WhileTransform,
+  AsyncTransform,
+  AwaitTransform,
 } from './transforms';
 
 export default class Env {
@@ -58,6 +60,8 @@ export default class Env {
     this.map.set('yield', YieldTransform);
     this.map.set('throw', ThrowTransform);
     this.map.set('new', NewTransform);
+    this.map.set('async', AsyncTransform);
+    this.map.set('await', AwaitTransform);
   }
 
   has(key) {

--- a/src/operators.js
+++ b/src/operators.js
@@ -8,6 +8,7 @@ const unaryOperators = {
   typeof: true,
   void: true,
   delete: true,
+  await: true,
 };
 const binaryOperatorPrecedence = {
   '*': 14,

--- a/src/term-expander.js
+++ b/src/term-expander.js
@@ -524,6 +524,11 @@ export default class TermExpander extends ASTDispatcher {
   }
 
   expandUnaryExpression(term) {
+    if (term.operator === 'await') {
+      return new T.AwaitExpression({
+        expression: this.expand(term.operand),
+      });
+    }
     return new T.UnaryExpression({
       operator: term.operator,
       operand: this.expand(term.operand),

--- a/src/term-expander.js
+++ b/src/term-expander.js
@@ -767,7 +767,7 @@ export default class TermExpander extends ASTDispatcher {
 
   expandIdentifierExpression(term) {
     let trans = this.context.env.get(term.name.resolve(this.context.phase));
-    if (trans) {
+    if (trans && trans.id) {
       return new T.IdentifierExpression({
         name: trans.id,
       });

--- a/src/term-expander.js
+++ b/src/term-expander.js
@@ -645,7 +645,7 @@ export default class TermExpander extends ASTDispatcher {
       this.context.phase,
       this.context.env,
       this.context.store,
-      this.context,
+      Object.assign({}, this.context, { allowAwait: term.isAsync }),
     );
 
     let bodyTerm;

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -81,7 +81,6 @@ export const TokenType = {
   IN: { klass: TC.Keyword, name: 'in' },
   NOT: { klass: TC.Punctuator, name: '!' },
   BIT_NOT: { klass: TC.Punctuator, name: '~' },
-  AWAIT: { klass: TC.Keyword, name: 'await' },
   DELETE: { klass: TC.Keyword, name: 'delete' },
   TYPEOF: { klass: TC.Keyword, name: 'typeof' },
   VOID: { klass: TC.Keyword, name: 'void' },
@@ -183,8 +182,6 @@ export const punctuatorTable = {
 };
 
 export const keywordTable = {
-  // 'await': TT.AWAIT, TODO: uncomment when new version of shift is used
-  // TODO: add 'async'
   break: TT.BREAK,
   case: TT.CASE,
   catch: TT.CATCH,

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -29,6 +29,8 @@ export class SyntaxrecDeclTransform {}
 export class SyntaxDeclTransform {}
 export class OperatorDeclTransform {}
 export class ReturnStatementTransform {}
+export class AsyncTransform {}
+export class AwaitTransform {}
 export class ModuleNamespaceTransform {
   namespace: Syntax;
   mod: SweetModule;

--- a/test/parser/__snapshots__/test-ast.js.snap
+++ b/test/parser/__snapshots__/test-ast.js.snap
@@ -128,3 +128,406 @@ Module {
   "type": "Module",
 }
 `;
+
+exports[`includes no-line-terminator requirement for async function expressions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    VariableDeclarationStatement {
+      "declaration": VariableDeclaration {
+        "declarators": Array [
+          VariableDeclarator {
+            "binding": BindingIdentifier {
+              "loc": null,
+              "name": "f_2",
+              "type": "BindingIdentifier",
+            },
+            "init": IdentifierExpression {
+              "loc": null,
+              "name": "async",
+              "type": "IdentifierExpression",
+            },
+            "loc": null,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "kind": "let",
+        "loc": null,
+        "type": "VariableDeclaration",
+      },
+      "loc": null,
+      "type": "VariableDeclarationStatement",
+    },
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [],
+        "type": "FunctionBody",
+      },
+      "isAsync": undefined,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f_2",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes no-line-terminator requirement for async functions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    ExpressionStatement {
+      "expression": IdentifierExpression {
+        "loc": null,
+        "name": "async",
+        "type": "IdentifierExpression",
+      },
+      "loc": null,
+      "type": "ExpressionStatement",
+    },
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [],
+        "type": "FunctionBody",
+      },
+      "isAsync": undefined,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for async arrow functions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    VariableDeclarationStatement {
+      "declaration": VariableDeclaration {
+        "declarators": Array [
+          VariableDeclarator {
+            "binding": BindingIdentifier {
+              "loc": null,
+              "name": "f_3",
+              "type": "BindingIdentifier",
+            },
+            "init": ArrowExpression {
+              "body": FunctionBody {
+                "directives": Array [],
+                "loc": null,
+                "statements": Array [],
+                "type": "FunctionBody",
+              },
+              "isAsync": true,
+              "loc": null,
+              "params": FormalParameters {
+                "items": Array [],
+                "loc": null,
+                "rest": null,
+                "type": "FormalParameters",
+              },
+              "type": "ArrowExpression",
+            },
+            "loc": null,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "kind": "let",
+        "loc": null,
+        "type": "VariableDeclaration",
+      },
+      "loc": null,
+      "type": "VariableDeclarationStatement",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for async function declarations 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [],
+        "type": "FunctionBody",
+      },
+      "isAsync": true,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for async function expressions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    VariableDeclarationStatement {
+      "declaration": VariableDeclaration {
+        "declarators": Array [
+          VariableDeclarator {
+            "binding": BindingIdentifier {
+              "loc": null,
+              "name": "f_1",
+              "type": "BindingIdentifier",
+            },
+            "init": FunctionExpression {
+              "body": FunctionBody {
+                "directives": Array [],
+                "loc": null,
+                "statements": Array [],
+                "type": "FunctionBody",
+              },
+              "isAsync": true,
+              "isGenerator": false,
+              "loc": null,
+              "name": BindingIdentifier {
+                "loc": null,
+                "name": "f_1",
+                "type": "BindingIdentifier",
+              },
+              "params": FormalParameters {
+                "items": Array [],
+                "loc": null,
+                "rest": null,
+                "type": "FormalParameters",
+              },
+              "type": "FunctionExpression",
+            },
+            "loc": null,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "kind": "let",
+        "loc": null,
+        "type": "VariableDeclaration",
+      },
+      "loc": null,
+      "type": "VariableDeclarationStatement",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for async functions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [],
+        "type": "FunctionBody",
+      },
+      "isAsync": true,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for async method definitions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    ClassDeclaration {
+      "elements": Array [
+        ClassElement {
+          "isStatic": false,
+          "loc": null,
+          "method": Method {
+            "body": FunctionBody {
+              "directives": Array [],
+              "loc": null,
+              "statements": Array [],
+              "type": "FunctionBody",
+            },
+            "isAsync": true,
+            "isGenerator": false,
+            "loc": null,
+            "name": StaticPropertyName {
+              "loc": null,
+              "type": "StaticPropertyName",
+              "value": "f",
+            },
+            "params": FormalParameters {
+              "items": Array [],
+              "loc": null,
+              "rest": null,
+              "type": "FormalParameters",
+            },
+            "type": "Method",
+          },
+          "type": "ClassElement",
+        },
+      ],
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "C",
+        "type": "BindingIdentifier",
+      },
+      "super": null,
+      "type": "ClassDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for exporting async functions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [],
+        "type": "FunctionBody",
+      },
+      "isAsync": true,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+    ExportLocals {
+      "loc": null,
+      "moduleSpecifier": null,
+      "namedExports": Array [
+        ExportLocalSpecifier {
+          "exportedName": "f",
+          "loc": null,
+          "name": IdentifierExpression {
+            "loc": null,
+            "name": "f",
+            "type": "IdentifierExpression",
+          },
+          "type": "ExportLocalSpecifier",
+        },
+      ],
+      "type": "ExportLocals",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
+exports[`includes support for exporting default async functions 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    ExportDefault {
+      "body": FunctionExpression {
+        "body": FunctionBody {
+          "directives": Array [],
+          "loc": null,
+          "statements": Array [],
+          "type": "FunctionBody",
+        },
+        "isAsync": true,
+        "isGenerator": false,
+        "loc": null,
+        "name": BindingIdentifier {
+          "loc": null,
+          "name": "f",
+          "type": "BindingIdentifier",
+        },
+        "params": FormalParameters {
+          "items": Array [],
+          "loc": null,
+          "rest": null,
+          "type": "FormalParameters",
+        },
+        "type": "FunctionExpression",
+      },
+      "loc": null,
+      "type": "ExportDefault",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;

--- a/test/parser/__snapshots__/test-ast.js.snap
+++ b/test/parser/__snapshots__/test-ast.js.snap
@@ -445,6 +445,58 @@ Module {
 }
 `;
 
+exports[`includes support for await 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    FunctionDeclaration {
+      "body": FunctionBody {
+        "directives": Array [],
+        "loc": null,
+        "statements": Array [
+          ExpressionStatement {
+            "expression": AwaitExpression {
+              "expression": CallExpression {
+                "arguments": Array [],
+                "callee": IdentifierExpression {
+                  "loc": null,
+                  "name": "g",
+                  "type": "IdentifierExpression",
+                },
+                "loc": null,
+                "type": "CallExpression",
+              },
+              "loc": null,
+              "type": "AwaitExpression",
+            },
+            "loc": null,
+            "type": "ExpressionStatement",
+          },
+        ],
+        "type": "FunctionBody",
+      },
+      "isAsync": true,
+      "isGenerator": false,
+      "loc": null,
+      "name": BindingIdentifier {
+        "loc": null,
+        "name": "f",
+        "type": "BindingIdentifier",
+      },
+      "params": FormalParameters {
+        "items": Array [],
+        "loc": null,
+        "rest": null,
+        "type": "FormalParameters",
+      },
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
 exports[`includes support for exporting async functions 1`] = `
 Module {
   "directives": Array [],

--- a/test/parser/__snapshots__/test-ast.js.snap
+++ b/test/parser/__snapshots__/test-ast.js.snap
@@ -23,6 +23,56 @@ Module {
 }
 `;
 
+exports[`handles properties named async 1`] = `
+Module {
+  "directives": Array [],
+  "items": Array [
+    VariableDeclarationStatement {
+      "declaration": VariableDeclaration {
+        "declarators": Array [
+          VariableDeclarator {
+            "binding": BindingIdentifier {
+              "loc": null,
+              "name": "o_4",
+              "type": "BindingIdentifier",
+            },
+            "init": ObjectExpression {
+              "loc": null,
+              "properties": Array [
+                DataProperty {
+                  "expression": LiteralBooleanExpression {
+                    "loc": null,
+                    "type": "LiteralBooleanExpression",
+                    "value": true,
+                  },
+                  "loc": null,
+                  "name": StaticPropertyName {
+                    "loc": null,
+                    "type": "StaticPropertyName",
+                    "value": "async",
+                  },
+                  "type": "DataProperty",
+                },
+              ],
+              "type": "ObjectExpression",
+            },
+            "loc": null,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "kind": "let",
+        "loc": null,
+        "type": "VariableDeclaration",
+      },
+      "loc": null,
+      "type": "VariableDeclarationStatement",
+    },
+  ],
+  "loc": null,
+  "type": "Module",
+}
+`;
+
 exports[`includes export declaration in AST 1`] = `
 Module {
   "directives": Array [],

--- a/test/parser/test-ast.js
+++ b/test/parser/test-ast.js
@@ -40,3 +40,71 @@ test('includes export declaration in AST', t => {
     `),
   );
 });
+
+test('includes support for async function declarations', t => {
+  t.snapshot(
+    getAst(`
+    async function f() {}
+    `),
+  );
+});
+
+test('includes support for async function expressions', t => {
+  t.snapshot(
+    getAst(`
+    let f = async function f() {}
+    `),
+  );
+});
+
+test('includes support for exporting async functions', t => {
+  t.snapshot(
+    getAst(`
+    export async function f() {}
+    `),
+  );
+});
+
+test('includes support for exporting default async functions', t => {
+  t.snapshot(
+    getAst(`
+    export default async function f() {}
+    `),
+  );
+});
+
+test('includes no-line-terminator requirement for async functions', t => {
+  t.snapshot(
+    getAst(`
+    async 
+    function f() {}
+    `),
+  );
+});
+
+test('includes no-line-terminator requirement for async function expressions', t => {
+  t.snapshot(
+    getAst(`
+    let f = async 
+    function f() {}
+    `),
+  );
+});
+
+test('includes support for async arrow functions', t => {
+  t.snapshot(
+    getAst(`
+    let f = async () => {}
+    `),
+  );
+});
+
+test('includes support for async method definitions', t => {
+  t.snapshot(
+    getAst(`
+    class C {
+      async f() {}
+    }
+    `),
+  );
+});

--- a/test/parser/test-ast.js
+++ b/test/parser/test-ast.js
@@ -108,3 +108,13 @@ test('includes support for async method definitions', t => {
     `),
   );
 });
+
+test('includes support for await', t => {
+  t.snapshot(
+    getAst(`
+    async function f () {
+      await g();
+    }
+    `),
+  );
+});

--- a/test/parser/test-ast.js
+++ b/test/parser/test-ast.js
@@ -109,6 +109,16 @@ test('includes support for async method definitions', t => {
   );
 });
 
+test('handles properties named async', t => {
+  t.snapshot(
+    getAst(`
+    let o = {
+      async: true
+    }
+    `),
+  );
+});
+
 test('includes support for await', t => {
   t.snapshot(
     getAst(`


### PR DESCRIPTION
This PR adds support in sweet's parser but shift-codegen doesn't support async/await yet so it won't be usable until support has been added there.